### PR TITLE
Fix the 5 second deadlock from lambda to router

### DIFF
--- a/src/PwrDrvr.LambdaDispatch.LambdaLB/HttpDuplexContent.cs
+++ b/src/PwrDrvr.LambdaDispatch.LambdaLB/HttpDuplexContent.cs
@@ -26,6 +26,10 @@ public class HttpDuplexContent : HttpContent
 
   protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
   {
+    // Flush the stream to force sending the request headers
+    // If we do not do this we can deadlock
+    // https://github.com/huntharo/httpclient-duplex-deadlock/tree/main
+    await stream.FlushAsync();
     _waitForCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
     _waitForStream.SetResult(stream);
     await _waitForCompletion.Task;


### PR DESCRIPTION
- Issue was due to `HEADERS` frame not being flushed
- https://github.com/huntharo/httpclient-duplex-deadlock