### PR TITLE
Issue 71 - A few final cleanups for background dispatch

### DIFF
--- a/src/PwrDrvr.LambdaDispatch.Router/Program.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Program.cs
@@ -4,7 +4,7 @@ namespace PwrDrvr.LambdaDispatch.Router;
 
 public class Program
 {
-    public static async Task Main(string[] args)
+    public static void Main(string[] args)
     {
         CreateHostBuilder(args).Build().Run();
     }


### PR DESCRIPTION
- Shorten the number of quick loops - we are just checking for a race condition
- Exit the quick loop as soon as there are no pending requests
- Make the channel bounded - this may happen to a few requests but it is an extreme edge case and we're just trying to prime the pump to get things going