### PR TITLE
Issue 5 - Connections independent of requests

### DIFF
--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
@@ -168,6 +168,8 @@ public class LambdaInstance : ILambdaInstance
 
   private readonly int maxConcurrentCount;
 
+  private readonly int channelCount;
+
   private readonly IAmazonLambda LambdaClient;
 
   public string Id { get; private set; } = Guid.NewGuid().ToString();
@@ -231,10 +233,11 @@ public class LambdaInstance : ILambdaInstance
   /// <exception cref="ArgumentNullException"></exception>
   /// <exception cref="ArgumentException"></exception>
   /// <exception cref="ArgumentOutOfRangeException"></exception>
-  public LambdaInstance(int maxConcurrentCount, string functionName, string? functionQualifier = null, IAmazonLambda? lambdaClient = null, IBackgroundDispatcher? dispatcher = null)
+  public LambdaInstance(int maxConcurrentCount, string functionName, string? functionQualifier = null, IAmazonLambda? lambdaClient = null, IBackgroundDispatcher? dispatcher = null, int channelCount = -1)
   {
     ArgumentNullException.ThrowIfNull(dispatcher);
     this.dispatcher = dispatcher;
+    this.channelCount = channelCount;
     if (string.IsNullOrWhiteSpace(functionName))
     {
       throw new ArgumentException("Cannot be null or whitespace", nameof(functionName));
@@ -584,7 +587,7 @@ public class LambdaInstance : ILambdaInstance
     {
       Id = Id,
       DispatcherUrl = await GetCallbackIP.Get(),
-      NumberOfChannels = maxConcurrentCount * 2,
+      NumberOfChannels = channelCount == -1 ? 2 * maxConcurrentCount : channelCount,
       SentTime = DateTime.Now
     };
 

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
@@ -208,8 +208,12 @@ public class LambdaInstance : ILambdaInstance
   /// <summary>
   /// The number of connections that we should use
   /// We may have more connections than we are supposed to use, we hide these
+  /// 
+  /// OutstandingRequestCount can go slightly higher than the limit
+  /// when there are pre-emptive connections because we don't do
+  /// aggressive locking as it is too expensive.
   /// </summary>
-  public int AvailableConnectionCount => Math.Min(Math.Max(maxConcurrentCount - OutstandingRequestCount, 0), internalActualAvailableConnectionCount);
+  public int AvailableConnectionCount => Math.Min(Math.Max(maxConcurrentCount - Math.Min(OutstandingRequestCount, maxConcurrentCount), 0), internalActualAvailableConnectionCount);
   private int signaledStarting = 0;
 
   private int signalClosing = 0;

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
@@ -49,6 +49,8 @@ public class LambdaInstanceManager : ILambdaInstanceManager
 
   private readonly int _maxConcurrentCount;
 
+  private readonly int _channelCount;
+
   private readonly string _functionName;
 
   private readonly string? _functionNameQualifier;
@@ -62,6 +64,7 @@ public class LambdaInstanceManager : ILambdaInstanceManager
   public LambdaInstanceManager(IConfig config)
   {
     _maxConcurrentCount = config.MaxConcurrentCount;
+    _channelCount = config.ChannelCount;
     _leastOutstandingQueue = new(_maxConcurrentCount);
     _functionName = config.FunctionNameOnly;
     _functionNameQualifier = config.FunctionNameQualifier;
@@ -292,7 +295,7 @@ public class LambdaInstanceManager : ILambdaInstanceManager
   public void DebugAddInstance(string instanceId)
   {
     // Start a new LambdaInstance and add it to the list
-    var instance = new LambdaInstance(_maxConcurrentCount, _functionName, _functionNameQualifier);
+    var instance = new LambdaInstance(_maxConcurrentCount, _functionName, _functionNameQualifier, channelCount: _channelCount, dispatcher: _dispatcher);
 
     instance.FakeStart(instanceId);
 
@@ -325,7 +328,7 @@ public class LambdaInstanceManager : ILambdaInstanceManager
     MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStartingCount, _startingInstanceCount);
 
     // Start a new LambdaInstance and add it to the list
-    var instance = new LambdaInstance(_maxConcurrentCount, _functionName, _functionNameQualifier, dispatcher: _dispatcher);
+    var instance = new LambdaInstance(_maxConcurrentCount, _functionName, _functionNameQualifier, channelCount: _channelCount, dispatcher: _dispatcher);
 
     // Add the instance to the collection
     if (!_instances.TryAdd(instance.Id, instance))

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
@@ -35,21 +35,41 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       // Start the Lambda
       await instance.Start();
 
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
+
       Assert.That(instance.AddConnection(request.Object, response.Object, "channel-1", false), Is.Not.Null);
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(1));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(1));
-      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(9));
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
 
       await instance.AddConnection(request.Object, response.Object, "channel-2", false);
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(2));
       await instance.AddConnection(request.Object, response.Object, "channel-3", false);
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(3));
       await instance.AddConnection(request.Object, response.Object, "channel-4", false);
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(4));
       await instance.AddConnection(request.Object, response.Object, "channel-5", false);
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(5));
       await instance.AddConnection(request.Object, response.Object, "channel-6", false);
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(6));
       await instance.AddConnection(request.Object, response.Object, "channel-7", false);
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(7));
       await instance.AddConnection(request.Object, response.Object, "channel-8", false);
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(8));
       await instance.AddConnection(request.Object, response.Object, "channel-9", false);
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(9));
       await instance.AddConnection(request.Object, response.Object, "channel-10", false);
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(10));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(10));
@@ -62,6 +82,92 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(11));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(10));
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task AddConnection_ShouldHideSurplusConnections()
+    {
+      var maxConcurrentCount = 10;
+      var lambdaClient = new Mock<IAmazonLambda>();
+      var instance = new LambdaInstance(maxConcurrentCount, "somefunc", null, lambdaClient.Object);
+
+      var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
+      var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
+      request.Setup(i => i.HttpContext).Returns(requestContext.Object);
+      var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
+
+      // Start the Lambda
+      await instance.Start();
+
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
+
+      // These should be visible
+      for (var i = 1; i <= maxConcurrentCount; i++)
+      {
+        Assert.That(instance.AddConnection(request.Object, response.Object, $"channel-{i}", false), Is.Not.Null);
+        Assert.That(instance.QueueApproximateCount, Is.EqualTo(i));
+        Assert.That(instance.AvailableConnectionCount, Is.EqualTo(i));
+        Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      }
+
+      // These should be hidden
+      for (var i = 1; i <= maxConcurrentCount; i++)
+      {
+        Assert.That(instance.AddConnection(request.Object, response.Object, $"channel-{i + 10}", false), Is.Not.Null);
+        Assert.That(instance.QueueApproximateCount, Is.EqualTo(i + maxConcurrentCount));
+        Assert.That(instance.AvailableConnectionCount, Is.EqualTo(maxConcurrentCount));
+        Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      }
+
+      // Should give back only the non-hidden connections
+      for (var i = 1; i <= maxConcurrentCount; i++)
+      {
+        Assert.That(instance.TryGetConnection(out var connection), Is.True);
+        Assert.That(connection, Is.Not.Null);
+        Assert.That(connection.ChannelId, Is.EqualTo($"channel-{i}"));
+        Assert.That(instance.QueueApproximateCount, Is.EqualTo(maxConcurrentCount - i + maxConcurrentCount));
+        Assert.That(instance.AvailableConnectionCount, Is.EqualTo(maxConcurrentCount - i));
+        Assert.That(instance.OutstandingRequestCount, Is.EqualTo(i));
+      }
+
+      // Should not give back the hidden connections
+      for (var i = 1; i <= maxConcurrentCount; i++)
+      {
+        Assert.That(instance.TryGetConnection(out var connection), Is.False);
+        Assert.That(connection, Is.Null);
+        Assert.That(instance.QueueApproximateCount, Is.EqualTo(maxConcurrentCount));
+        Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
+        Assert.That(instance.OutstandingRequestCount, Is.EqualTo(maxConcurrentCount));
+      }
+    }
+
+    [Test]
+    public async Task AddConnection_ImmediateDispatchShouldCountAsOutstanding()
+    {
+      var maxConcurrentCount = 10;
+      var lambdaClient = new Mock<IAmazonLambda>();
+      var instance = new LambdaInstance(maxConcurrentCount, "somefunc", null, lambdaClient.Object);
+
+      var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
+      var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
+      request.Setup(i => i.HttpContext).Returns(requestContext.Object);
+      var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
+
+      // Start the Lambda
+      await instance.Start();
+
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
+      Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
+
+      // These should not be visible but should count as outstanding
+      for (var i = 1; i <= maxConcurrentCount; i++)
+      {
+        Assert.That(instance.AddConnection(request.Object, response.Object, $"channel-{i}", immediateDispatch: true), Is.Not.Null);
+        Assert.That(instance.QueueApproximateCount, Is.EqualTo(0));
+        Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
+        Assert.That(instance.OutstandingRequestCount, Is.EqualTo(i));
+      }
     }
 
     [Test]
@@ -83,7 +189,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(1));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(1));
-      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(9));
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
 
       await instance.AddConnection(request.Object, response.Object, "channel-2", false);
       await instance.AddConnection(request.Object, response.Object, "channel-3", false);
@@ -91,20 +197,20 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(4));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(4));
-      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(6));
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
 
       Assert.That(instance.TryGetConnection(out var connection), Is.True);
       Assert.That(connection, Is.Not.Null);
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(3));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(3));
-      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(7));
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(1));
 
       // Reinstate the connection
       await instance.ReenqueueUnusedConnection(connection);
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(4));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(4));
-      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(6));
+      Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
     }
   }
 }

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
@@ -16,8 +16,11 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
     [Test]
     public void Constructor_ShouldRejectTooSmallMaxConcurrentCount()
     {
-      Assert.Throws<ArgumentOutOfRangeException>(() => new LambdaInstance(0, "somefunc"));
-      Assert.Throws<ArgumentOutOfRangeException>(() => new LambdaInstance(-1, "somefunc"));
+      var lambdaClient = new Mock<IAmazonLambda>();
+      var dispatcher = new Mock<IBackgroundDispatcher>();
+
+      Assert.Throws<ArgumentOutOfRangeException>(() => new LambdaInstance(0, "somefunc", "$LATEST", lambdaClient.Object, dispatcher.Object));
+      Assert.Throws<ArgumentOutOfRangeException>(() => new LambdaInstance(-1, "somefunc", "$LATEST", lambdaClient.Object, dispatcher.Object));
     }
 
     [Test]
@@ -25,7 +28,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
     {
       var maxConcurrentCount = 10;
       var lambdaClient = new Mock<IAmazonLambda>();
-      var instance = new LambdaInstance(maxConcurrentCount, "somefunc", null, lambdaClient.Object);
+      var dispatcher = new Mock<IBackgroundDispatcher>();
+      var instance = new LambdaInstance(maxConcurrentCount, "somefunc", null, lambdaClient.Object, dispatcher.Object);
 
       var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
       var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
@@ -89,7 +93,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
     {
       var maxConcurrentCount = 10;
       var lambdaClient = new Mock<IAmazonLambda>();
-      var instance = new LambdaInstance(maxConcurrentCount, "somefunc", null, lambdaClient.Object);
+      var dispatcher = new Mock<IBackgroundDispatcher>();
+      var instance = new LambdaInstance(maxConcurrentCount, "somefunc", null, lambdaClient.Object, dispatcher.Object);
 
       var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
       var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
@@ -147,7 +152,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
     {
       var maxConcurrentCount = 10;
       var lambdaClient = new Mock<IAmazonLambda>();
-      var instance = new LambdaInstance(maxConcurrentCount, "somefunc", null, lambdaClient.Object);
+      var dispatcher = new Mock<IBackgroundDispatcher>();
+      var instance = new LambdaInstance(maxConcurrentCount, "somefunc", null, lambdaClient.Object, dispatcher.Object);
 
       var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
       var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
@@ -175,7 +181,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
     {
       var maxConcurrentCount = 10;
       var lambdaClient = new Mock<IAmazonLambda>();
-      var instance = new LambdaInstance(maxConcurrentCount, "someFunc", null, lambdaClient.Object);
+      var dispatcher = new Mock<IBackgroundDispatcher>();
+      var instance = new LambdaInstance(maxConcurrentCount, "someFunc", null, lambdaClient.Object, dispatcher.Object);
 
       var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
       var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
@@ -114,6 +114,14 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       Assert.IsTrue(result);
       Assert.IsNotNull(dequeuedConnection);
+
+      // Getting another instance should fail
+      instance.Setup(i => i.OutstandingRequestCount).Returns(1);
+      instance.Setup(i => i.TryGetConnection(out connectionObject)).Returns(false);
+      result = queue.TryGetLeastOustandingConnection(out dequeuedConnection);
+
+      Assert.IsFalse(result);
+      Assert.IsNull(dequeuedConnection);
     }
 
     [Test]

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
@@ -44,8 +44,9 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var maxConcurrentCount = 10;
       using var queue = new LeastOutstandingQueue(maxConcurrentCount);
       var lambdaClient = new Mock<IAmazonLambda>();
+      var dispatcher = new Mock<IBackgroundDispatcher>();
 
-      var instance = new LambdaInstance(maxConcurrentCount, "someFunc", null, lambdaClient.Object);
+      var instance = new LambdaInstance(maxConcurrentCount, "someFunc", null, lambdaClient.Object, dispatcher.Object);
       queue.AddInstance(instance);
 
       var result = queue.TryGetLeastOustandingConnection(out var connection);


### PR DESCRIPTION
- Add Least Outstanding Queue test
- Count the number of connections for a lambda independently of the number of outstanding requests for it
- A low number of outstanding requests makes an instance is relatively idle even if it has only 1 remaining open connection (e.g. if it has not yet re-established connections that were just used)
- Instances with low counts of outstanding requests should be dispatched to first, but once the last open connection is used (even if not the max) then they should be moved to the full instance list