### PR TITLE
Issue 20 - Duplex router request response

### DIFF
--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaConnection.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaConnection.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.AspNetCore.Connections;
 
 namespace PwrDrvr.LambdaDispatch.Router;
 
@@ -57,6 +58,8 @@ public class LambdaConnection
   /// </summary>
   public TaskCompletionSource TCS { get; private set; } = new TaskCompletionSource();
 
+  private CancellationTokenSource CTS = new CancellationTokenSource();
+
   public LambdaConnection(HttpRequest request, HttpResponse response, ILambdaInstance instance, string channelId)
   {
     Request = request;
@@ -104,15 +107,15 @@ public class LambdaConnection
     // as 200 if this connection was in the queue
     // There will either be no subsequent connection or it will
     // get immediately rejected with a 409
-    await Response.WriteAsync($"GET /_lambda_dispatch/goaway HTTP/1.1\r\nX-Lambda-Id: {Instance.Id}\r\nX-Channel-Id: {ChannelId}\r\n\r\n");
+    await Response.WriteAsync($"GET /_lambda_dispatch/goaway HTTP/1.1\r\nX-Lambda-Id: {Instance.Id}\r\nX-Channel-Id: {ChannelId}\r\n\r\n", CTS.Token);
     await Response.CompleteAsync();
     try { await Request.Body.CopyToAsync(Stream.Null); } catch { }
 
-    this.TCS.SetResult();
+    TCS.SetResult();
   }
 
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
-  public async Task ProxyRequestToLambda(HttpRequest incomingRequest)
+  private async Task ProxyRequestToLambda(HttpRequest incomingRequest)
   {
     // Send the incoming Request on the lambda's Response
     _logger.LogDebug("Sending incoming request headers to Lambda");
@@ -145,7 +148,7 @@ public class LambdaConnection
       offset += 2;
 
       // Send the headers to the Lambda
-      await Response.BodyWriter.WriteAsync(headerBuffer.AsMemory(0, offset)).ConfigureAwait(false);
+      await Response.BodyWriter.WriteAsync(headerBuffer.AsMemory(0, offset), CTS.Token).ConfigureAwait(false);
 
       // Only copy the request body if the request has a body
       if (incomingRequest.ContentLength > 0 || (incomingRequest.Headers.ContainsKey("Transfer-Encoding") && incomingRequest.Headers["Transfer-Encoding"] == "chunked"))
@@ -159,9 +162,9 @@ public class LambdaConnection
           // Read from the source stream and write to the destination stream in a loop
           int bytesRead;
           var responseStream = incomingRequest.Body;
-          while ((bytesRead = await responseStream.ReadAsync(bytes, 0, bytes.Length)) > 0)
+          while ((bytesRead = await responseStream.ReadAsync(bytes, CTS.Token)) > 0)
           {
-            await Response.Body.WriteAsync(bytes, 0, bytesRead);
+            await Response.BodyWriter.WriteAsync(bytes.AsMemory(0, bytesRead), CTS.Token);
           }
         }
         finally
@@ -203,84 +206,106 @@ public class LambdaConnection
       // Set the state to busy
       State = LambdaConnectionState.Busy;
 
-      //
-      // Send the incoming request to the Lambda
-      // TODO: This should be done in parallel with reading the response
-      // and both tasks should be awaited
-      //
-      await ProxyRequestToLambda(incomingRequest).ConfigureAwait(false);
+      var proxyRequestTask = ProxyRequestToLambda(incomingRequest);
+      var proxyResponseTask = RelayResponseFromLambda(incomingResponse);
 
-      //
-      //
-      // Read response from Lambda and relay back to caller
-      //
-      //
-
-      await RelayResponseFromLambda(incomingResponse).ConfigureAwait(false);
-    }
-    // This happens when the client aborts the request and we are still reading
-    catch (BadHttpRequestException)
-    {
-      if (this.Request.Headers.TryGetValue("Date", out var dateValues)
-          && dateValues.Count == 1
-          && DateTime.TryParse(dateValues.ToString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var requestDate))
+      // Wait for both to finish
+      // This allows us to continue sending request body while receiving
+      // and relaying the response body (duplex)
+      var completedTask = await Task.WhenAny(proxyRequestTask, proxyResponseTask).ConfigureAwait(false);
+      if (completedTask.Exception != null)
       {
-        var duration = DateTime.UtcNow - requestDate;
+        throw completedTask.Exception;
+      }
 
-        _logger.LogError("LambdaConnection.RunRequest - BadHttpRequestException - Request was received at {RequestDate}, {DurationInSeconds} seconds ago, LambdaID: {LambdaId}, ChannelId: {ChannelId}",
-            requestDate.ToLocalTime().ToString("o"),
-            duration.TotalSeconds,
-            this.Instance.Id,
-            this.ChannelId);
+      if (completedTask == proxyRequestTask)
+      {
+        // ProxyRequestToLambda finished first
+        // Wait for RelayResponseFromLambda to finish
+        await proxyResponseTask.ConfigureAwait(false);
       }
       else
       {
-        _logger.LogError("LambdaConnection.RunRequest - BadHttpRequestException - Receipt time not known");
+        // RelayResponseFromLambda finished first
+        // Wait for ProxyRequestToLambda to finish
+        await proxyRequestTask.ConfigureAwait(false);
       }
-
-      // We have to abort the connection for HTTP/1.1 or the stream
-      // for HTTP2 because we don't know if we sent or finished the whole
-      // request or not.
-      try { this.Request.HttpContext.Abort(); } catch { }
-
-      // We re-raise the exception so Kestrel will cleanup the incoming request
-      // if anything is left of it
-      throw;
     }
-    catch (Exception ex)
+    catch (AggregateException ae)
     {
-      if (this.Request.Headers.TryGetValue("Date", out var dateValues)
-          && dateValues.Count == 1
-          && DateTime.TryParse(dateValues.ToString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var requestDate))
+      foreach (var ex in ae.InnerExceptions)
       {
-        var duration = DateTime.UtcNow - requestDate;
+        var logExceptionStack = false;
 
-        _logger.LogError(ex, "LambdaConnection.RunRequest - Exception - Request was received at {RequestDate}, {DurationInSeconds} seconds ago, LambdaID: {LambdaId}, ChannelId: {ChannelId}",
-            requestDate.ToLocalTime().ToString("o"),
-            duration.TotalSeconds,
-            this.Instance.Id,
-            this.ChannelId);
+        // This happens when the client aborts the request and we are still reading
+        if (ex is BadHttpRequestException || ex is ConnectionResetException)
+        {
+          logExceptionStack = false;
+        }
+        else
+        {
+          logExceptionStack = true;
+        }
+
+        if (Request.Headers.TryGetValue("Date", out var dateValues)
+                  && dateValues.Count == 1
+                  && DateTime.TryParse(dateValues.ToString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var requestDate))
+        {
+          var duration = DateTime.UtcNow - requestDate;
+
+          if (logExceptionStack)
+          {
+            _logger.LogError(ex, "LambdaConnection.RunRequest - Exception - Request was received at {RequestDate}, {DurationInSeconds} seconds ago, LambdaID: {LambdaId}, ChannelId: {ChannelId}",
+                requestDate.ToLocalTime().ToString("o"),
+                duration.TotalSeconds,
+                Instance.Id,
+                ChannelId);
+          }
+          else
+          {
+            _logger.LogError("LambdaConnection.RunRequest - Exception - Request was received at {RequestDate}, {DurationInSeconds} seconds ago, LambdaID: {LambdaId}, ChannelId: {ChannelId}",
+                requestDate.ToLocalTime().ToString("o"),
+                duration.TotalSeconds,
+                Instance.Id,
+                ChannelId);
+          }
+        }
+        else
+        {
+          if (logExceptionStack)
+          {
+            _logger.LogError(ex, "LambdaConnection.RunRequest - Exception - Receipt time not known, LambdaID: {LambdaId}, ChannelId: {ChannelId}",
+                Instance.Id,
+                ChannelId);
+          }
+          else
+          {
+            _logger.LogError("LambdaConnection.RunRequest - Exception - Receipt time not known, LambdaID: {LambdaId}, ChannelId: {ChannelId}",
+                Instance.Id,
+                ChannelId);
+          }
+        }
+
+        // We have to abort the connection for HTTP/1.1 or the stream
+        // for HTTP2 because we don't know if we sent or finished the whole
+        // request or not.
+        try { Request.HttpContext.Abort(); } catch { }
+        try { incomingRequest.HttpContext.Abort(); } catch { }
+
+        // Just in case anything is still stuck
+        CTS.Cancel();
       }
-      else
-      {
-        _logger.LogError(ex, "LambdaConnection.RunRequest - Exception - Receipt time not known");
-      }
-
-      // We have to abort the connection for HTTP/1.1 or the stream
-      // for HTTP2 because we don't know if we sent or finished the whole
-      // request or not.
-      try { this.Request.HttpContext.Abort(); } catch { }
-
-      // We re-raise the exception so Kestrel will cleanup the incoming request
-      // if anything is left of it
-      throw;
     }
     finally
     {
       // Set the state to closed
       State = LambdaConnectionState.Closed;
 
-      try { await incomingResponse.CompleteAsync().ConfigureAwait(false); } catch { }
+      try
+      {
+        await incomingResponse.CompleteAsync().ConfigureAwait(false);
+      }
+      catch { }
 
       // Mark that the Response has been sent on the LambdaInstance
       TCS.SetResult();
@@ -309,7 +334,7 @@ public class LambdaConnection
           break;
         }
 
-        var bytesRead = await Request.Body.ReadAsync(headerBuffer, totalBytesRead, headerBuffer.Length - totalBytesRead).ConfigureAwait(false);
+        var bytesRead = await Request.Body.ReadAsync(headerBuffer.AsMemory(totalBytesRead, headerBuffer.Length - totalBytesRead), CTS.Token).ConfigureAwait(false);
         if (bytesRead == 0)
         {
           // Done reading
@@ -421,7 +446,7 @@ public class LambdaConnection
       {
         // There are bytes left in the buffer
         // Copy them to the response
-        await incomingResponse.BodyWriter.WriteAsync(headerBuffer.AsMemory(startOfNextLine, totalBytesRead - startOfNextLine)).ConfigureAwait(false);
+        await incomingResponse.BodyWriter.WriteAsync(headerBuffer.AsMemory(startOfNextLine, totalBytesRead - startOfNextLine), CTS.Token).ConfigureAwait(false);
       }
     }
     finally
@@ -435,9 +460,9 @@ public class LambdaConnection
       // Read from the source stream and write to the destination stream in a loop
       int bytesRead;
       var responseStream = Request.Body;
-      while ((bytesRead = await responseStream.ReadAsync(bytes, 0, bytes.Length).ConfigureAwait(false)) > 0)
+      while ((bytesRead = await responseStream.ReadAsync(bytes, CTS.Token).ConfigureAwait(false)) > 0)
       {
-        await incomingResponse.Body.WriteAsync(bytes, 0, bytesRead).ConfigureAwait(false);
+        await incomingResponse.Body.WriteAsync(bytes.AsMemory(0, bytesRead), CTS.Token).ConfigureAwait(false);
       }
     }
     finally


### PR DESCRIPTION
- Rust extension can handle duplex request/response (`/echo`) but dotnet extension can only handle simplex request/response still (`/echo-slow`)
- Relaying the `oha` binary (`9771960` bytes) locally on an M2 Max goes from 74 RPS before to 76-78 RPS after
- This should also enable long-lived request/responses used as a socket as in this application

Fixes #20 

## After

### After - 10 Concurrent Requests

```log
oha -c 10 -z 10s -m POST -T application/octet-stream -D ./oha http://localhost:5001/echo
Summary:
  Success rate: 100.00%
  Total:        10.0010 secs
  Slowest:      0.4269 secs
  Fastest:      0.1223 secs
  Average:      0.1307 secs
  Requests/sec: 75.9927

  Total data:   6.92 GiB
  Size/request: 9.32 MiB
  Size/sec:     708.20 MiB

Response time histogram:
  0.122 [1]   |
  0.153 [749] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.183 [0]   |
  0.214 [0]   |
  0.244 [0]   |
  0.275 [0]   |
  0.305 [0]   |
  0.336 [2]   |
  0.366 [3]   |
  0.396 [2]   |
  0.427 [3]   |

Response time distribution:
  10.00% in 0.1241 secs
  25.00% in 0.1252 secs
  50.00% in 0.1264 secs
  75.00% in 0.1280 secs
  90.00% in 0.1312 secs
  95.00% in 0.1425 secs
  99.00% in 0.3390 secs
  99.90% in 0.4269 secs
  99.99% in 0.4269 secs


Details (average, fastest, slowest):
  DNS+dialup:   0.0019 secs, 0.0016 secs, 0.0020 secs
  DNS-lookup:   0.0008 secs, 0.0008 secs, 0.0009 secs

Status code distribution:
  [200] 760 responses
```

### After - 1 Concurrent Request

```log
oha -c 1 -z 10s -m POST -T application/octet-stream -D ./oha http://localhost:5001/echo
Summary:
  Success rate: 100.00%
  Total:        10.0004 secs
  Slowest:      0.0523 secs
  Fastest:      0.0106 secs
  Average:      0.0127 secs
  Requests/sec: 78.4966

  Total data:   7.14 GiB
  Size/request: 9.32 MiB
  Size/sec:     731.53 MiB

Response time histogram:
  0.011 [1]   |
  0.015 [744] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.019 [33]  |■
  0.023 [4]   |
  0.027 [1]   |
  0.031 [1]   |
  0.036 [0]   |
  0.040 [0]   |
  0.044 [0]   |
  0.048 [0]   |
  0.052 [1]   |

Response time distribution:
  10.00% in 0.0117 secs
  25.00% in 0.0121 secs
  50.00% in 0.0124 secs
  75.00% in 0.0129 secs
  90.00% in 0.0135 secs
  95.00% in 0.0149 secs
  99.00% in 0.0186 secs
  99.90% in 0.0523 secs
  99.99% in 0.0523 secs


Details (average, fastest, slowest):
  DNS+dialup:   0.0008 secs, 0.0008 secs, 0.0008 secs
  DNS-lookup:   0.0002 secs, 0.0002 secs, 0.0002 secs

Status code distribution:
  [200] 785 responses
```


## Before

### Before - 10 Concurrent Requsets

```log
oha -c 10 -z 10s -m POST -T application/octet-stream -D ./oha http://localhost:5001/echo
Summary:
  Success rate: 100.00%
  Total:        10.0010 secs
  Slowest:      0.3460 secs
  Fastest:      0.1280 secs
  Average:      0.1343 secs
  Requests/sec: 73.9923

  Total data:   6.73 GiB
  Size/request: 9.32 MiB
  Size/sec:     689.55 MiB

Response time histogram:
  0.128 [1]   |
  0.150 [729] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.172 [0]   |
  0.193 [0]   |
  0.215 [0]   |
  0.237 [2]   |
  0.259 [1]   |
  0.281 [2]   |
  0.302 [1]   |
  0.324 [2]   |
  0.346 [2]   |

Response time distribution:
  10.00% in 0.1300 secs
  25.00% in 0.1308 secs
  50.00% in 0.1321 secs
  75.00% in 0.1332 secs
  90.00% in 0.1351 secs
  95.00% in 0.1369 secs
  99.00% in 0.2481 secs
  99.90% in 0.3460 secs
  99.99% in 0.3460 secs


Details (average, fastest, slowest):
  DNS+dialup:   0.0007 secs, 0.0005 secs, 0.0008 secs
  DNS-lookup:   0.0002 secs, 0.0001 secs, 0.0002 secs

Status code distribution:
  [200] 740 responses
```

### Before - 1 Concurrent Request

```log
oha -c 1 -z 10s -m POST -T application/octet-stream -D ./oha http://localhost:5001/echo
Summary:
  Success rate: 100.00%
  Total:        10.0007 secs
  Slowest:      0.0272 secs
  Fastest:      0.0120 secs
  Average:      0.0136 secs
  Requests/sec: 73.6949

  Total data:   6.71 GiB
  Size/request: 9.32 MiB
  Size/sec:     686.78 MiB

Response time histogram:
  0.012 [1]   |
  0.014 [446] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.015 [273] |■■■■■■■■■■■■■■■■■■■
  0.017 [10]  |
  0.018 [4]   |
  0.020 [1]   |
  0.021 [0]   |
  0.023 [1]   |
  0.024 [0]   |
  0.026 [0]   |
  0.027 [1]   |

Response time distribution:
  10.00% in 0.0129 secs
  25.00% in 0.0131 secs
  50.00% in 0.0134 secs
  75.00% in 0.0138 secs
  90.00% in 0.0143 secs
  95.00% in 0.0147 secs
  99.00% in 0.0166 secs
  99.90% in 0.0272 secs
  99.99% in 0.0272 secs


Details (average, fastest, slowest):
  DNS+dialup:   0.0007 secs, 0.0007 secs, 0.0007 secs
  DNS-lookup:   0.0001 secs, 0.0001 secs, 0.0001 secs

Status code distribution:
  [200] 737 responses
```