### PR TITLE
Issue 86 - Logging / debug `/echo` hang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +176,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +209,8 @@ name = "extension"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "env_logger",
  "flume",
  "futures",
  "http-body-util",
@@ -196,6 +220,7 @@ dependencies = [
  "hyper-util",
  "lambda-extension",
  "lambda_runtime",
+ "log",
  "pin-project-lite",
  "procfs",
  "rand",
@@ -453,6 +478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +564,17 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -877,6 +919,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "ring"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1186,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1417,6 +1497,37 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/ChannelError.md
+++ b/ChannelError.md
@@ -1,0 +1,7 @@
+ChannelId: channel-39fee888-8024-4913-92f1-b5eba7ff9ae3 - Error reading from res_stream: Some(hyper::Error(Body, Error { kind: Reset(StreamId(137), INTERNAL_ERROR, Remote) }))
+Connection failed: hyper::Error(User(BodyWriteAborted), NotEof(2202744))
+ChannelId: channel-39fee888-8024-4913-92f1-b5eba7ff9ae3 - Error reading from app_res_stream: Some(hyper::Error(Body, "connection error"))
+ChannelId: channel-5e1f1d8b-4402-43c1-bbef-b4e6adbec63a - Error reading from res_stream: Some(hyper::Error(Body, Error { kind: Reset(StreamId(139), INTERNAL_ERROR, Remote) }))
+Connection failed: hyper::Error(User(BodyWriteAborted), NotEof(1002616))
+thread 'main' panicked at extension/src/run.rs:229:23:
+Connection ready check threw error - connection has disconnected, should reconnect

--- a/ChannelError.md
+++ b/ChannelError.md
@@ -1,7 +1,0 @@
-ChannelId: channel-39fee888-8024-4913-92f1-b5eba7ff9ae3 - Error reading from res_stream: Some(hyper::Error(Body, Error { kind: Reset(StreamId(137), INTERNAL_ERROR, Remote) }))
-Connection failed: hyper::Error(User(BodyWriteAborted), NotEof(2202744))
-ChannelId: channel-39fee888-8024-4913-92f1-b5eba7ff9ae3 - Error reading from app_res_stream: Some(hyper::Error(Body, "connection error"))
-ChannelId: channel-5e1f1d8b-4402-43c1-bbef-b4e6adbec63a - Error reading from res_stream: Some(hyper::Error(Body, Error { kind: Reset(StreamId(139), INTERNAL_ERROR, Remote) }))
-Connection failed: hyper::Error(User(BodyWriteAborted), NotEof(1002616))
-thread 'main' panicked at extension/src/run.rs:229:23:
-Connection ready check threw error - connection has disconnected, should reconnect

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -261,7 +261,7 @@ sudo apt-get install lldb
 
 AWS_LAMBDA_SERVICE_URL=http://host.docker.internal:5051 AWS_ACCESS_KEY_ID=test-access-key-id AWS_SECRET_ACCESS_KEY=test-secret-access-key AWS_SESSION_TOKEN=test-session-token src/PwrDrvr.LambdaDispatch.Router/bin/Release/net8.0/PwrDrvr.LambdaDispatch.Router 2>&1 | tee router.log
 
-AWS_LAMBDA_RUNTIME_API=host.docker.internal:5051 AWS_REGION=us-east-2 AWS_ACCESS_KEY_ID=test-access-key-id AWS_SECRET_ACCESS_KEY=test-secret-access-key AWS_SESSION_TOKEN=test-session-token src/PwrDrvr.LambdaDispatch.Extension/bin/Release/net8.0/bootstrap 2>&1 | tee lambdalb.log
+AWS_LAMBDA_RUNTIME_API=host.docker.internal:5051 AWS_REGION=us-east-2 AWS_ACCESS_KEY_ID=test-access-key-id AWS_SECRET_ACCESS_KEY=test-secret-access-key AWS_SESSION_TOKEN=test-session-token src/PwrDrvr.LambdaDispatch.Extension/bin/Release/net8.0/bootstrap 2>&1 | tee extension.log
 
 # Running the Native version under dev container
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/workspaces/lambda-dispatch/src/PwrDrvr.LambdaDispatch.Extension/bin/Release/net8.0/linux-arm64/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,11 +30,23 @@ dotnet build
 
 ## Running Locally
 
+### DotNet Router
+
 ```sh
 dotnet run --project PwrDrvr.LambdaDispatch.Router
 
 LAMBDA_DISPATCH_ChannelCount=1 LAMBDA_DISPATCH_AllowInsecureControlChannel=true LAMBDA_DISPATCH_PreferredControlChannelScheme=http LAMBDA_DISPATCH_MaxConcurrentCount=1 DOTNET_ThreadPool_UnfairSemaphoreSpinLimit=5 LAMBDA_DISPATCH_FunctionName=dogs AWS_LAMBDA_SERVICE_URL=http://localhost:5051 AWS_REGION=us-east-2 AWS_ACCESS_KEY_ID=test-access-key-id AWS_SECRET_ACCESS_KEY=test-secret-access-key AWS_SESSION_TOKEN=test-session-token src/PwrDrvr.LambdaDispatch.Router/bin/Release/net8.0/PwrDrvr.LambdaDispatch.Router
+```
 
+### Rust Lambda Extension
+
+```sh
+AWS_LAMBDA_FUNCTION_VERSION=\$LATEST AWS_LAMBDA_FUNCTION_MEMORY_SIZE=512 AWS_LAMBDA_FUNCTION_NAME=dogs AWS_LAMBDA_RUNTIME_API=localhost:5051 AWS_REGION=us-east-2 AWS_ACCESS_KEY_ID=test-access-key-id AWS_SECRET_ACCESS_KEY=test-secret-access-key AWS_SESSION_TOKEN=test-session-token cargo run --release --bin extension
+```
+
+### DotNet Lambda Extension
+
+```sh
 DOTNET_ThreadPool_UnfairSemaphoreSpinLimit=0 AWS_LAMBDA_RUNTIME_API=localhost:5051 AWS_REGION=us-east-2 AWS_ACCESS_KEY_ID=test-access-key-id AWS_SECRET_ACCESS_KEY=test-secret-access-key AWS_SESSION_TOKEN=test-session-token src/PwrDrvr.LambdaDispatch.Extension/bin/Release/net8.0/bootstrap
 ```
 
@@ -83,18 +95,20 @@ aws cloudformation update-stack --stack-name lambda-dispatch-ecr-public --templa
 ```sh
 aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 220761759939.dkr.ecr.us-east-2.amazonaws.com
 
-docker build --file DockerfileRouter -t lambda-dispatch-router . \
-&& docker tag lambda-dispatch-router:latest 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-router:latest \
-&& docker push 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-router:latest
+docker build --file DockerfileRouter -t lambda-dispatch-router . &&\
+docker tag lambda-dispatch-router:latest 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-router:latest &&\
+docker push 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-router:latest
 ```
 
-## Build the Docker Image - Extension
+## Publish the Docker Image - Lambda Demo App from Public Image
 
 ```sh
-docker build --file DockerfileExtension -t lambda-dispatch-extension .
+docker pull public.ecr.aws/pwrdrvr/lambda-dispatch-demo-app:main && \
+docker tag public.ecr.aws/pwrdrvr/lambda-dispatch-demo-app:main 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-demo-app:latest && \
+docker push 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-demo-app:latest
 ```
 
-## Publish the Docker Image - Lambda Demo App
+## Publish the Docker Image - Lambda Demo App from Local Code
 
 ```sh
 docker build --file DockerfileExtension -t lambda-dispatch-extension . &&\

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.38"
+env_logger = "0.10.1"
+log = "0.4.20"
+chrono = "0.4.31"
 tokio = { version = "1.14.0", features = ["full"] }
 tokio-stream = "0.1.14"
 hyper = { version = "1.1.0", features = ["client"] }

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4.20"
 chrono = "0.4.31"
 tokio = { version = "1.14.0", features = ["full"] }
 tokio-stream = "0.1.14"
+tokio-util = "0.7.10"
 hyper = { version = "1.1.0", features = ["client"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1.2", features = ["full"] }

--- a/extension/src/app_request.rs
+++ b/extension/src/app_request.rs
@@ -70,7 +70,7 @@ pub async fn read_until_req_headers(
         return Ok((app_req_bld, false, left_over_buf));
       }
       Ok(httparse::Status::Partial) => {
-        println!("Partial header received, waiting for more data");
+        log::debug!("Partial header received, waiting for more data");
       }
       Err(e) => {
         Err(anyhow::anyhow!("Failed to parse headers: {:?}", e))?;

--- a/extension/src/counter_drop.rs
+++ b/extension/src/counter_drop.rs
@@ -1,0 +1,9 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub struct DecrementOnDrop<'a>(pub &'a AtomicUsize);
+
+impl<'a> Drop for DecrementOnDrop<'a> {
+  fn drop(&mut self) {
+    self.0.fetch_sub(1, Ordering::SeqCst);
+  }
+}

--- a/extension/src/main.rs
+++ b/extension/src/main.rs
@@ -14,6 +14,7 @@ use crate::time::current_time_millis;
 mod app_request;
 mod app_start;
 mod cert;
+mod counter_drop;
 mod messages;
 mod ping;
 mod run;

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -29,7 +29,7 @@ pub async fn send_ping_requests(
   scheme: String,
   host: String,
   port: u16,
-  deadline: u64,
+  deadline_ms: u64,
   cancel_sleep: tokio_util::sync::CancellationToken,
 ) {
   while goaway_received.load(std::sync::atomic::Ordering::Relaxed) == false {
@@ -38,7 +38,7 @@ pub async fn send_ping_requests(
     let last_active_ago_ms = time::current_time_millis() - last_active.load(Ordering::Relaxed);
     // TODO: Compute time we should stop at based on the initial function timeout duration
     if last_active_ago_ms > 1 * last_active_grace_period_ms
-      || time::current_time_millis() + close_before_deadline_ms > deadline
+      || time::current_time_millis() + close_before_deadline_ms > deadline_ms
     {
       if last_active_ago_ms > 1 * last_active_grace_period_ms {
         log::info!(
@@ -46,11 +46,11 @@ pub async fn send_ping_requests(
           lambda_id.clone(),
           last_active_ago_ms
         );
-      } else if time::current_time_millis() + close_before_deadline_ms > deadline {
+      } else if time::current_time_millis() + close_before_deadline_ms > deadline_ms {
         log::info!(
           "LambdaId: {}, Deadline: {} ms Away - Requesting close",
           lambda_id.clone(),
-          deadline - time::current_time_millis()
+          deadline_ms - time::current_time_millis()
         );
       }
       goaway_received.store(true, Ordering::Relaxed);

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -178,7 +178,7 @@ pub async fn send_ping_requests(
     tokio::time::sleep(Duration::from_secs(5)).await;
   }
 
-  println!(
+  log::info!(
     "LambdaId: {}, Requests: {}, GoAway: {} - Ping Loop - Exiting",
     lambda_id,
     count.load(Ordering::Relaxed),

--- a/extension/src/run.rs
+++ b/extension/src/run.rs
@@ -267,7 +267,7 @@ pub async fn run(
                           let chunk_len = chunk.as_ref().unwrap().data_ref().unwrap().len();
                           // If chunk_len is zero the channel has closed
                           if chunk_len == 0 {
-                            println!("LambdaId: {}, ChannelId: {}, BytesSent: {}, ChunkLen: {} - Channel closed", lambda_id_clone.clone(), channel_id_clone.clone(), bytes_sent, chunk_len);
+                            log::debug!("LambdaId: {}, ChannelId: {}, BytesSent: {}, ChunkLen: {} - Channel closed", lambda_id_clone.clone(), channel_id_clone.clone(), bytes_sent, chunk_len);
                             break;
                           }
                           match app_req_tx.send(Ok(chunk.unwrap())).await {

--- a/fargate.template.yaml
+++ b/fargate.template.yaml
@@ -410,6 +410,8 @@ Resources:
       TargetGroupAttributes:
         - Key: load_balancing.algorithm.type
           Value: 'least_outstanding_requests'
+        - Key: deregistration_delay.timeout_seconds
+          Value: '60'
 
   LambdaLBTable:
     Type: 'AWS::DynamoDB::Table'

--- a/src/PwrDrvr.LambdaDispatch.Extension/HttpReverseRequester.cs
+++ b/src/PwrDrvr.LambdaDispatch.Extension/HttpReverseRequester.cs
@@ -175,8 +175,8 @@ public class HttpReverseRequester
       // Read until we fill the bufer OR we get an EOF
       int totalBytesRead = 0;
       int idxToExamine = 0;
-      int idxPriorLineFeed = -1;
-      int idxHeadersLast = -1;
+      int idxPriorLineFeed = int.MinValue;
+      int idxHeadersLast = int.MinValue;
       while (true)
       {
         if (totalBytesRead >= headerBuffer.Length)
@@ -214,7 +214,7 @@ public class HttpReverseRequester
           }
         }
 
-        if (idxHeadersLast != -1)
+        if (idxHeadersLast != int.MinValue)
         {
           // We found the `\r\n\r\n` sequence
           // We are done reading
@@ -228,7 +228,7 @@ public class HttpReverseRequester
       //
 
       // Read the status line
-      int endOfStatusLine = Array.IndexOf(headerBuffer, (byte)'\n');
+      int endOfStatusLine = Array.IndexOf(headerBuffer, (byte)'\n', 0, totalBytesRead);
       if (endOfStatusLine == -1)
       {
         // Handle error: '\n' not found in the buffer
@@ -287,7 +287,7 @@ public class HttpReverseRequester
       while (startOfNextLine < totalBytesRead)
       {
         // Find the index of the next '\n' in headerBuffer
-        int endOfLine = Array.IndexOf(headerBuffer, (byte)'\n', startOfNextLine);
+        int endOfLine = Array.IndexOf(headerBuffer, (byte)'\n', startOfNextLine, totalBytesRead - startOfNextLine);
         if (endOfLine == -1)
         {
           // No more '\n' found

--- a/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
@@ -37,10 +37,11 @@ public class ChunkedController : ControllerBase
   }
 
   [HttpGet]
-  [Route("close/{instanceId}")]
-  public IActionResult CloseInstance(string instanceId)
+  [Route("close/{lambdaId}")]
+  public IActionResult CloseInstance(string lambdaId)
   {
-    dispatcher.CloseInstance(instanceId);
+    logger.LogInformation("Router.ChunkedController.CloseInstance - Closing LambdaId: {lambdaId}", lambdaId);
+    dispatcher.CloseInstance(lambdaId);
 
     return Ok();
   }

--- a/src/PwrDrvr.LambdaDispatch.Router/Dispatcher.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Dispatcher.cs
@@ -85,8 +85,6 @@ public class Dispatcher : IBackgroundDispatcher
 
   public void CloseInstance(string instanceId)
   {
-    _logger.LogDebug("Closing instance {instanceId}", instanceId);
-
     _lambdaInstanceManager.CloseInstance(instanceId);
   }
 

--- a/src/PwrDrvr.LambdaDispatch.Router/Dispatcher.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Dispatcher.cs
@@ -304,6 +304,8 @@ public class Dispatcher : IBackgroundDispatcher
   /// <returns>Whether a request was dispatched</returns>
   public async Task<bool> TryBackgroundDispatchOne(bool countAsForeground = false)
   {
+    var startedRequest = false;
+
     try
     {
       // If there should be pending requests, try to get a connection then grab a request
@@ -323,6 +325,7 @@ public class Dispatcher : IBackgroundDispatcher
         // Try to get a pending request
         if (_pendingRequests.TryDequeue(out var pendingRequest))
         {
+          startedRequest = true;
           pendingRequest.RecordDispatchTime();
           _logger.LogDebug("Dispatching pending request");
 
@@ -385,7 +388,7 @@ public class Dispatcher : IBackgroundDispatcher
     catch (Exception ex)
     {
       _logger.LogError(ex, "TryBackgroundDispatchOne - Exception");
-      throw;
+      return startedRequest;
     }
   }
 }

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaConnection.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaConnection.cs
@@ -368,7 +368,7 @@ public class LambdaConnection
           }
         }
 
-        if (idxHeadersLast != -1)
+        if (idxHeadersLast != int.MinValue)
         {
           // We found the `\r\n\r\n` sequence
           // We are done reading

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
@@ -488,7 +488,7 @@ public class LambdaInstance : ILambdaInstance
   }
 
   /// <summary>
-  /// Closes in the background so the Lambda can exist as soon as it sees it's last connection close
+  /// Closes in the background so the Lambda can exit as soon as it sees it's last connection close
   /// </summary>
   public void Close(bool doNotReplace = false)
   {

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
@@ -255,6 +255,7 @@ public class LambdaInstanceManager : ILambdaInstanceManager
             stoppingInstances.Add(leastBusyInstance.Id, leastBusyInstance);
 
             // Close the instance
+            _logger.LogInformation("ManageCapacity - Closing least busy instance, LambdaId: {lambdaId}", leastBusyInstance.Id);
             CloseInstance(leastBusyInstance);
           }
           else
@@ -406,8 +407,6 @@ public class LambdaInstanceManager : ILambdaInstanceManager
   /// <param name="instance"></param>
   public void CloseInstance(ILambdaInstance instance)
   {
-    _logger.LogInformation("Closing instance {instanceId}", instance.Id);
-
     // The instance is going to get cleaned up by the OnInvocationComplete handler
     // Counts will be decremented, the instance will be replaced, etc.
     // We just need to get the Lambda to return from the invoke
@@ -421,11 +420,9 @@ public class LambdaInstanceManager : ILambdaInstanceManager
   /// <returns></returns>
   public void CloseInstance(string instanceId)
   {
-    _logger.LogInformation("Closing instance {instanceId}", instanceId);
-
     if (_instances.TryGetValue(instanceId, out var instance))
     {
-      this.CloseInstance(instance);
+      CloseInstance(instance);
     }
     else
     {


### PR DESCRIPTION
- Converted extension to a logging framework from `println`
- Fixed uninitialized memory read in the Router when parsing HTTP
- Fixed error when first char was `\n` of HTTP response
- Added logging statements and in-flight-request counting
- All in an attempt to debug the hang on `/echo` that only happens when deployed to Lambda (obviously a race condition of some sort)