### PR TITLE
Issue 89 - Add init-only lambda invokes

### DIFF
--- a/extension/src/messages.rs
+++ b/extension/src/messages.rs
@@ -11,6 +11,8 @@ pub struct WaiterRequest {
   pub number_of_channels: i32,
   #[serde(rename = "SentTime")]
   pub sent_time: String,
+  #[serde(rename = "InitOnly")]
+  pub init_only: bool,
 }
 
 #[derive(Serialize, Debug)]

--- a/extension/src/messages.rs
+++ b/extension/src/messages.rs
@@ -11,7 +11,7 @@ pub struct WaiterRequest {
   pub number_of_channels: i32,
   #[serde(rename = "SentTime")]
   pub sent_time: String,
-  #[serde(rename = "InitOnly")]
+  #[serde(rename = "InitOnly", default)]
   pub init_only: bool,
 }
 

--- a/src/PwrDrvr.LambdaDispatch.Extension/Function.cs
+++ b/src/PwrDrvr.LambdaDispatch.Extension/Function.cs
@@ -250,6 +250,12 @@ public class Function
 
             using var lambdaIdScope = _logger.BeginScope("LambdaId: {LambdaId}", request.Id);
 
+            if (request.InitOnly)
+            {
+                _logger.LogInformation("InitOnly is true, returning");
+                return new WaiterResponse { Id = request.Id };
+            }
+
             // TODO: We can potentially make this static or a map on dispatcherUrl to requester
             // Each request repeats the Lambda ID and we do not need to re-establish sockets
             // if the DispatcherUrl has not actually changed

--- a/src/PwrDrvr.LambdaDispatch.Messages/Waiter.cs
+++ b/src/PwrDrvr.LambdaDispatch.Messages/Waiter.cs
@@ -22,6 +22,12 @@ public class WaiterRequest
   /// Set the time that the message was sent
   /// </summary>
   public DateTime SentTime { get; set; }
+
+  /// <summary>
+  /// Only initialize the Lambda instance, don't open any channels, then return
+  /// If already initialized, returns immediately
+  /// </summary>
+  public bool InitOnly { get; set; }
 }
 
 public class WaiterResponse

--- a/src/PwrDrvr.LambdaDispatch.Router/MetricsRegistry.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/MetricsRegistry.cs
@@ -198,6 +198,12 @@ public static class MetricsRegistry
     MeasurementUnit = Unit.Items,
   };
 
+  public static readonly GaugeOptions LambdaInstanceStoppingCount = new()
+  {
+    Name = "LambdaInstanceStoppingCount",
+    MeasurementUnit = Unit.Items,
+  };
+
   public static readonly GaugeOptions LambdaInstanceRunningCount = new()
   {
     Name = "LambdaInstanceRunningCount",


### PR DESCRIPTION
- Invoke a "buddy" lambda each time we start a lambda
  - The buddy lambda only performs the init then returns
  - This is a way to nearly-guarantee that we will have an exec env ready when an exec env ends normally before it's timeout is reached
- Start the replacement lambda as soon as a lambda asks for a close
  - This prevents a drop in capacity during instance replacement
  - This can be rather pronounced when running only a few instances
- Remove stopping instances from the count of which instances satisfy the desired instance count 
- Use locks around instance state changes - these are rare but allowing double transitions will throw off the counts of running instances

Fixes #89 