### PR TITLE
Issue 91 - Fix URL Path

### DIFF
--- a/src/demo-app/app.cjs
+++ b/src/demo-app/app.cjs
@@ -54,6 +54,10 @@ app.get("/ping", async (req, res) => {
   res.send("pong");
 });
 
+app.get("/headers", async (req, res) => {
+  res.json(req.headers);
+});
+
 app.get("/delay", async (req, res) => {
   const delay = req.query.delay || 20;
   await sleep(delay);


### PR DESCRIPTION
- Only pass the path on the request to the contained app
- Add a `/headers` method to the demo-app to reply with the headers
- Mark the POST to the router as `application/octet-stream` not as `application/json`