### PR TITLE
Issue 101 - Pass through query string

### DIFF
--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaConnection.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaConnection.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Extensions;
 
 namespace PwrDrvr.LambdaDispatch.Router;
 
@@ -127,7 +128,7 @@ public class LambdaConnection
       int offset = 0;
 
       // Write the request line to the buffer
-      var requestLine = $"{incomingRequest.Method} {incomingRequest.Path} {incomingRequest.Protocol}\r\n";
+      var requestLine = $"{incomingRequest.Method} {incomingRequest.GetEncodedPathAndQuery()} {incomingRequest.Protocol}\r\n";
       var requestLineBytes = Encoding.UTF8.GetBytes(requestLine);
       requestLineBytes.CopyTo(headerBuffer, offset);
       offset += requestLineBytes.Length;

--- a/src/demo-app/app.cjs
+++ b/src/demo-app/app.cjs
@@ -59,7 +59,7 @@ app.get("/headers", async (req, res) => {
 });
 
 app.get("/delay", async (req, res) => {
-  const delay = req.query.delay || 20;
+  const delay = parseInt(req.query.delay) || 20;
   await sleep(delay);
   res.send(`Delayed for ${delay} ms`);
 });


### PR DESCRIPTION
- Add the query string
- Make sure to use the encoded query and path

Fixes #101 