### PR TITLE
Issue 109 - Limit to 1 worker thread in Router

### DIFF
--- a/fargate.template.yaml
+++ b/fargate.template.yaml
@@ -59,8 +59,11 @@ Resources:
           Image: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/lambda-dispatch-router:latest'
           Essential: true
           Environment:
-            - Name: DOTNET_ThreadPool_UnfairSemaphoreSpinLimit
-              Value: "6"
+            - Name: LAMBDA_DISPATCH_MaxWorkerThreads
+              Value: "1"
+            # Limiting the spins is no longer needed when limiting to 1 thread
+            # - Name: DOTNET_ThreadPool_UnfairSemaphoreSpinLimit
+            #   Value: "6"
             - Name: LAMBDA_DISPATCH_FunctionName
               Value: !GetAtt LambdaDemoApp.Arn
             - Name: LAMBDA_DISPATCH_MaxConcurrentCount

--- a/src/PwrDrvr.LambdaDispatch.Router/Program.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Program.cs
@@ -4,15 +4,77 @@ namespace PwrDrvr.LambdaDispatch.Router;
 
 public class Program
 {
+    /// <summary>
+    /// Adjust the ThreadPool settings based on environment variables
+    /// LAMBDA_DISPATCH_MinWorkerThreads
+    /// LAMBDA_DISPATCH_MinCompletionPortThreads
+    /// LAMBDA_DISPATCH_MaxWorkerThreads
+    /// LAMBDA_DISPATCH_MaxCompletionPortThreads
+    /// 
+    /// Related to: DOTNET_ThreadPool_UnfairSemaphoreSpinLimit
+    /// </summary>
+    /// <exception cref="Exception"></exception>
+    public static void AdjustThreadPool()
+    {
+        // Get the default min and max number of worker and completionport threads
+        ThreadPool.GetMinThreads(out var minWorkerThreads, out var minCompletionPortThreads);
+        ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionPortThreads);
+
+        Console.WriteLine($"Default min threads: {minWorkerThreads} worker threads, {minCompletionPortThreads} completion port threads");
+        Console.WriteLine($"Default max threads: {maxWorkerThreads} worker threads, {maxCompletionPortThreads} completion port threads");
+
+        // Check for LAMBDA_DISPATCH_MaxWorkerThreads and LAMBDA_DISPATCH_MaxCompletionPortThreads and apply those new max limits if set
+        var maxWorkerThreadsEnv = Environment.GetEnvironmentVariable("LAMBDA_DISPATCH_MaxWorkerThreads");
+        var maxCompletionPortThreadsEnv = Environment.GetEnvironmentVariable("LAMBDA_DISPATCH_MaxCompletionPortThreads");
+        if (int.TryParse(maxWorkerThreadsEnv, out var newMaxWorkerThreads))
+        {
+            maxWorkerThreads = newMaxWorkerThreads;
+        }
+        if (int.TryParse(maxCompletionPortThreadsEnv, out var newMaxCompletionPortThreads))
+        {
+            maxCompletionPortThreads = newMaxCompletionPortThreads;
+        }
+
+        // Ensure min is less than or equal to max in the case where min/max are not overridden
+        minWorkerThreads = Math.Min(minWorkerThreads, maxWorkerThreads);
+        minCompletionPortThreads = Math.Min(minCompletionPortThreads, maxCompletionPortThreads);
+
+        // Override the calculated min value if set in an env var
+        var minWorkerThreadsEnv = Environment.GetEnvironmentVariable("LAMBDA_DISPATCH_MinWorkerThreads");
+        var minCompletionPortThreadsEnv = Environment.GetEnvironmentVariable("LAMBDA_DISPATCH_MinCompletionPortThreads");
+        if (int.TryParse(minWorkerThreadsEnv, out var newMinWorkerThreads))
+        {
+            minWorkerThreads = newMinWorkerThreads;
+        }
+        if (int.TryParse(minCompletionPortThreadsEnv, out var newMinCompletionPortThreads))
+        {
+            minCompletionPortThreads = newMinCompletionPortThreads;
+        }
+
+        var setMinResult = ThreadPool.SetMinThreads(minWorkerThreads, minCompletionPortThreads);
+        if (!setMinResult)
+        {
+            throw new Exception($"Failed to set min threads to {minWorkerThreads} worker threads, {minCompletionPortThreads} completion port threads");
+        }
+
+        var setResult = ThreadPool.SetMaxThreads(maxWorkerThreads, maxCompletionPortThreads);
+        if (!setResult)
+        {
+            throw new Exception($"Failed to set max threads to {maxWorkerThreads} worker threads, {maxCompletionPortThreads} completion port threads");
+        }
+
+        // Print the final max threads setting
+        ThreadPool.GetMinThreads(out minWorkerThreads, out minCompletionPortThreads);
+        ThreadPool.GetMaxThreads(out maxWorkerThreads, out maxCompletionPortThreads);
+        Console.WriteLine("");
+        Console.WriteLine($"Final min threads: {minWorkerThreads} worker threads, {minCompletionPortThreads} completion port threads");
+        Console.WriteLine($"Final max threads: {maxWorkerThreads} worker threads, {maxCompletionPortThreads} completion port threads");
+        Console.WriteLine("");
+    }
+
     public static void Main(string[] args)
     {
-        ThreadPool.SetMinThreads(1, 1);
-        ThreadPool.GetMaxThreads(out var workerThreads, out var completionPortThreads);
-        Console.WriteLine($"ThreadPool.GetMaxThreads returned {workerThreads} worker threads and {completionPortThreads} completion port threads");
-        var result = ThreadPool.SetMaxThreads(1, completionPortThreads);
-        Console.WriteLine($"ThreadPool.SetMaxThreads returned {result}");
-        ThreadPool.GetMaxThreads(out workerThreads, out completionPortThreads);
-        Console.WriteLine($"ThreadPool.GetMaxThreads returned {workerThreads} worker threads and {completionPortThreads} completion port threads");
+        AdjustThreadPool();
         CreateHostBuilder(args).Build().Run();
     }
 

--- a/src/PwrDrvr.LambdaDispatch.Router/Program.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Program.cs
@@ -6,6 +6,13 @@ public class Program
 {
     public static void Main(string[] args)
     {
+        ThreadPool.SetMinThreads(1, 1);
+        ThreadPool.GetMaxThreads(out var workerThreads, out var completionPortThreads);
+        Console.WriteLine($"ThreadPool.GetMaxThreads returned {workerThreads} worker threads and {completionPortThreads} completion port threads");
+        var result = ThreadPool.SetMaxThreads(1, completionPortThreads);
+        Console.WriteLine($"ThreadPool.SetMaxThreads returned {result}");
+        ThreadPool.GetMaxThreads(out workerThreads, out completionPortThreads);
+        Console.WriteLine($"ThreadPool.GetMaxThreads returned {workerThreads} worker threads and {completionPortThreads} completion port threads");
         CreateHostBuilder(args).Build().Run();
     }
 


### PR DESCRIPTION
## Results
- Deployed on ECS
  - 1 CPU: 4000 RPS -> 4500-5000 RPS with `-c 100` on `/ping`
  - Same response time and RPS rate as directlambda
- Locally
  - Cuts CPU from 380% to 120%
  - `-c 10` on `/ping`

## Video Review of Performance Improvement - YouTube

Click to view on YouTube

[![DotNot as efficient as Rust?](https://img.youtube.com/vi/jE5_EVSSVvc/maxresdefault.jpg)](https://www.youtube.com/watch?v=jE5_EVSSVvc)

Fixes #109 