### PR TITLE
Issue 124 - Drop Lambda Invoke retries

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "DynamicScalingInSuspended": true,
+  "DynamicScalingOutSuspended": true
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaClientConfig.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaClientConfig.cs
@@ -13,7 +13,7 @@ public static class LambdaClientConfig
     var config = new AmazonLambdaConfig
     {
       Timeout = TimeSpan.FromMinutes(15),
-      MaxErrorRetry = 8
+      MaxErrorRetry = 1,
     };
 
     if (!string.IsNullOrEmpty(serviceUrl))


### PR DESCRIPTION
- This no longer needs to be 8
- Set it to 1 to ensure that we do not "stack up" invokes
