### PR TITLE
Issue 124 - AWS Metadata Service & Embedded Metrics Logger

### DIFF
--- a/src/PwrDrvr.LambdaDispatch.Router/EmbeddedMetrics/MetricsLogger.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/EmbeddedMetrics/MetricsLogger.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using System.Threading.Channels;
+
+namespace PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
+
+public interface IMetricsLogger
+{
+  void PutMetric(string name, double value, Unit unit);
+}
+
+public class MetricsLogger : IMetricsLogger
+{
+  private class Metric
+  {
+    public string Name { get; set; }
+    public double Value { get; set; }
+    public Unit Unit { get; set; }
+  }
+
+  private class MetricData
+  {
+    public Unit Unit { get; set; }
+    public List<double> Values { get; set; } = new List<double>();
+  }
+
+  private readonly Channel<Metric> _channel;
+  private readonly string _namespace;
+  private readonly Dictionary<string, MetricData> _metrics = [];
+  private readonly Dictionary<string, string> _dimensions;
+  private readonly object _flushLock = new();
+  private DateTime _currentMinute;
+
+  public MetricsLogger(string metricsNamespace, Dictionary<string, string>? dimensions = null)
+  {
+    _namespace = metricsNamespace;
+    _channel = Channel.CreateBounded<Metric>(new BoundedChannelOptions(10000)
+    {
+      FullMode = BoundedChannelFullMode.DropOldest
+    });
+    if (dimensions != null)
+    {
+      ValidateDimensions(dimensions);
+    }
+    _dimensions = dimensions ?? [];
+
+    var now = DateTime.UtcNow;
+    _currentMinute = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, 0);
+
+    StartFlushTask();
+
+    Task.Run(ReadFromChannel);
+  }
+
+  public void PutMetric(string name, double value, Unit unit)
+  {
+    _channel.Writer.TryWrite(new Metric { Name = name, Value = value, Unit = unit });
+  }
+
+  private void UpdateCurrentMinute()
+  {
+    var now = DateTime.UtcNow;
+    var minute = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, 0);
+    _currentMinute = minute;
+  }
+
+  private void StartFlushTask()
+  {
+    Task.Run(async () =>
+    {
+      while (true)
+      {
+        var now = DateTime.UtcNow;
+        var nextMinute = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, 0).AddMinutes(1);
+        var delay = nextMinute - now;
+
+        await Task.Delay(delay);
+
+        lock (_flushLock)
+        {
+          Flush();
+          UpdateCurrentMinute();
+        }
+      }
+    });
+  }
+
+  private async Task ReadFromChannel()
+  {
+    await foreach (var metric in _channel.Reader.ReadAllAsync())
+    {
+      if (!_metrics.TryGetValue(metric.Name, out var metricData))
+      {
+        metricData = new MetricData { Unit = metric.Unit };
+        _metrics[metric.Name] = metricData;
+      }
+
+      metricData.Values.Add(metric.Value);
+
+      if (metricData.Values.Count >= 100)
+      {
+        lock (_flushLock)
+        {
+          FlushMetric(metric.Name, metricData);
+        }
+      }
+    }
+  }
+
+  /// <summary>
+  /// NOT thread safe - acquire the flush lock before calling
+  /// </summary>
+  private void Flush()
+  {
+    foreach (var pair in _metrics)
+    {
+      FlushMetric(pair.Key, pair.Value);
+    }
+
+    _metrics.Clear();
+  }
+
+  /// <summary>
+  /// NOT thread safe - acquire the flush lock before calling
+  /// </summary>
+  private void FlushMetric(string name, MetricData metricData)
+  {
+    // This can happen if we went to flush a single metric in ReadFromChannel but blocked on the
+    // lock, after which out metric was cleared of all values
+    if (metricData.Values.Count == 0)
+    {
+      return;
+    }
+
+    // Only write if we have non-zero values
+    if (metricData.Values.Any(v => v != 0))
+    {
+      var timestamp = (long)(_currentMinute - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds;
+      var emfData = new Dictionary<string, object>
+      {
+        ["_aws"] = new
+        {
+          Timestamp = timestamp,
+          CloudWatchMetrics = new[]
+              {
+                new
+                {
+                    Namespace = _namespace,
+                    Dimensions = new[] { _dimensions.Select(d => d.Key).ToArray() },
+                    Metrics = new[]
+                    {
+                        new
+                        {
+                            Name = name,
+                            // https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure_metricdefinition
+                            // https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
+                            Unit = metricData.Unit.ToString(),
+                        }
+                    }
+                }
+            }
+        },
+        [name] = metricData.Values,
+      };
+      foreach (var dimension in _dimensions)
+      {
+        emfData[dimension.Key] = dimension.Value;
+      }
+
+      string json = JsonSerializer.Serialize(emfData);
+      Console.WriteLine(json);
+    }
+
+    // Always clear the metric values
+    metricData.Values.Clear();
+  }
+
+  private static void ValidateDimensions(Dictionary<string, string> dimensions)
+  {
+    const int maxDimensions = 30;
+    const int maxDimensionValueLength = 1024;
+
+    if (dimensions.Count > maxDimensions)
+    {
+      throw new ArgumentException($"Too many dimensions. The maximum number of dimensions is {maxDimensions}.");
+    }
+
+    foreach (var dimension in dimensions)
+    {
+      if (dimension.Value == null || !(dimension.Value is string))
+      {
+        throw new ArgumentException($"Invalid dimension value. All dimension values must be strings.");
+      }
+
+      if (dimension.Value.Length > maxDimensionValueLength)
+      {
+        throw new ArgumentException($"Dimension value too long. The maximum length for a dimension value is {maxDimensionValueLength} characters.");
+      }
+    }
+  }
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/EmbeddedMetrics/Unit.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/EmbeddedMetrics/Unit.cs
@@ -1,0 +1,89 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum Unit
+{
+  [EnumMember(Value = "Seconds")]
+  Seconds,
+
+  [EnumMember(Value = "Microseconds")]
+  Microseconds,
+
+  [EnumMember(Value = "Milliseconds")]
+  Milliseconds,
+
+  [EnumMember(Value = "Bytes")]
+  Bytes,
+
+  [EnumMember(Value = "Kilobytes")]
+  Kilobytes,
+
+  [EnumMember(Value = "Megabytes")]
+  Megabytes,
+
+  [EnumMember(Value = "Gigabytes")]
+  Gigabytes,
+
+  [EnumMember(Value = "Terabytes")]
+  Terabytes,
+
+  [EnumMember(Value = "Bits")]
+  Bits,
+
+  [EnumMember(Value = "Kilobits")]
+  Kilobits,
+
+  [EnumMember(Value = "Megabits")]
+  Megabits,
+
+  [EnumMember(Value = "Gigabits")]
+  Gigabits,
+
+  [EnumMember(Value = "Terabits")]
+  Terabits,
+
+  [EnumMember(Value = "Percent")]
+  Percent,
+
+  [EnumMember(Value = "Count")]
+  Count,
+
+  [EnumMember(Value = "Bytes/Second")]
+  BytesPerSecond,
+
+  [EnumMember(Value = "Kilobytes/Second")]
+  KilobytesPerSecond,
+
+  [EnumMember(Value = "Megabytes/Second")]
+  MegabytesPerSecond,
+
+  [EnumMember(Value = "Gigabytes/Second")]
+  GigabytesPerSecond,
+
+  [EnumMember(Value = "Terabytes/Second")]
+  TerabytesPerSecond,
+
+  [EnumMember(Value = "Bits/Second")]
+  BitsPerSecond,
+
+  [EnumMember(Value = "Kilobits/Second")]
+  KilobitsPerSecond,
+
+  [EnumMember(Value = "Megabits/Second")]
+  MegabitsPerSecond,
+
+  [EnumMember(Value = "Gigabits/Second")]
+  GigabitsPerSecond,
+
+  [EnumMember(Value = "Terabits/Second")]
+  TerabitsPerSecond,
+
+  [EnumMember(Value = "Count/Second")]
+  CountPerSecond,
+
+  [EnumMember(Value = "None")]
+  None
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/GetCallbackIP.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/GetCallbackIP.cs
@@ -1,30 +1,25 @@
 namespace PwrDrvr.LambdaDispatch.Router;
 
-using System.Net.Http;
-using System.Text.Json;
-using System.Threading.Tasks;
-
-public class GetCallbackIP
+public static class GetCallbackIP
 {
   static private string? callbackUrl = null;
-
-  static private int performedInit = 0;
-
-  static private ReaderWriterLockSlim rwLock = new();
 
   static private string scheme = "https";
 
   static private int port = 5004;
 
-  static public ValueTask<string> Init(int port, string scheme)
+  static private string? networkIp;
+
+  static public string Init(int port, string scheme, string networkIp)
   {
     GetCallbackIP.port = port;
     GetCallbackIP.scheme = scheme;
+    GetCallbackIP.networkIp = networkIp;
 
     return Get();
   }
 
-  static public async ValueTask<string> Get()
+  static public string Get()
   {
     // Once it is set, it is set, we don't have to lock
     if (callbackUrl != null)
@@ -32,69 +27,12 @@ public class GetCallbackIP
       return callbackUrl;
     }
 
-    try
+    if (networkIp == null)
     {
-      // Wait for the one init to finish
-      rwLock.EnterUpgradeableReadLock();
-
-      // Only one thread should do the init
-      if (Interlocked.CompareExchange(ref performedInit, 1, 0) == 1)
-      {
-        if (callbackUrl == null)
-        {
-          throw new InvalidOperationException("Callback URL is null");
-        }
-        return callbackUrl;
-      }
-
-      // Upgrade the read lock to a write lock
-      rwLock.EnterWriteLock();
-
-      // We are the only thread that will get here, ever
-      using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-      using var client = new HttpClient();
-      try
-      {
-        var response = await client.GetStringAsync("http://169.254.170.2/v2/metadata", cts.Token);
-        Console.WriteLine(response);
-        var metadata = JsonDocument.Parse(response).RootElement;
-        // On ECS there is an extra Containers parent that is not in EC2
-        var containers = metadata.GetProperty("Containers");
-        foreach (var container in containers.EnumerateArray())
-        {
-          var networks = container.GetProperty("Networks");
-          foreach (var network in networks.EnumerateArray())
-          {
-            if (network.GetProperty("NetworkMode").GetString() == "awsvpc")
-            {
-              callbackUrl = $"{scheme}://{network.GetProperty("IPv4Addresses").EnumerateArray().First().GetString()}:{port}/api/chunked";
-              return callbackUrl;
-            }
-          }
-        }
-      }
-      catch (HttpRequestException)
-      {
-        // Ignore
-      }
-      catch (OperationCanceledException)
-      {
-        // Ignore
-      }
-
-      callbackUrl = $"{scheme}://{Environment.GetEnvironmentVariable("ROUTER_CALLBACK_HOST") ?? "127.0.0.1"}:{port}/api/chunked";
-      return callbackUrl;
+      throw new Exception("Network IP is not set");
     }
-    finally
-    {
-      if (rwLock.IsWriteLockHeld)
-      {
-        rwLock.ExitWriteLock();
-      }
-      if (rwLock.IsUpgradeableReadLockHeld)
-      {
-        rwLock.ExitUpgradeableReadLock();
-      }
-    }
+
+    callbackUrl = $"{scheme}://{Environment.GetEnvironmentVariable("ROUTER_CALLBACK_HOST") ?? networkIp}:{port}/api/chunked";
+    return callbackUrl;
   }
 }

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
@@ -632,7 +632,7 @@ public class LambdaInstance : ILambdaInstance
   /// This is a "buddy" to the `Start` call that uses the same parameters
   /// </summary>
   /// <returns></returns>
-  public async Task StartInitOnly()
+  public void StartInitOnly()
   {
 
     var initOnlyLambdaId = $"{Id}-initonly";
@@ -641,7 +641,7 @@ public class LambdaInstance : ILambdaInstance
     var payload = new WaiterRequest
     {
       Id = initOnlyLambdaId,
-      DispatcherUrl = await GetCallbackIP.Get(),
+      DispatcherUrl = GetCallbackIP.Get(),
       NumberOfChannels = 0,
       SentTime = DateTime.Now,
       InitOnly = true
@@ -685,7 +685,7 @@ public class LambdaInstance : ILambdaInstance
   /// Each instance can have many connections at a time to us
   /// </summary>
   /// <returns></returns>
-  public async Task Start()
+  public void Start()
   {
     _logger.LogInformation("Starting Lambda Instance {Id}", Id);
 
@@ -711,7 +711,7 @@ public class LambdaInstance : ILambdaInstance
     var payload = new WaiterRequest
     {
       Id = Id,
-      DispatcherUrl = await GetCallbackIP.Get(),
+      DispatcherUrl = GetCallbackIP.Get(),
       NumberOfChannels = channelCount == -1 ? 2 * maxConcurrentCount : channelCount,
       SentTime = DateTime.Now,
       InitOnly = false
@@ -766,7 +766,7 @@ public class LambdaInstance : ILambdaInstance
       await Task.Delay(TimeSpan.FromMilliseconds(100));
 
       // Start an init-only buddy
-      await StartInitOnly();
+      StartInitOnly();
     });
   }
 

--- a/src/PwrDrvr.LambdaDispatch.Router/MetadataService.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/MetadataService.cs
@@ -46,6 +46,8 @@ public class MetadataService : IMetadataService
         }
       }
 
+      response = _client.GetStringAsync($"{Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4")}/task", cts.Token).GetAwaiter().GetResult();
+      metadata = JsonDocument.Parse(response).RootElement;
       var taskArnParts = metadata.GetProperty("TaskARN").GetString().Split('/');
       _clusterName = taskArnParts.Length > 1 ? taskArnParts[1] : "";
     }

--- a/src/PwrDrvr.LambdaDispatch.Router/MetadataService.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/MetadataService.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Amazon.Util;
+
+namespace PwrDrvr.LambdaDispatch.Router;
+
+public interface IMetadataService
+{
+  string NetworkIP { get; }
+  string? ClusterName { get; }
+}
+
+public class MetadataService : IMetadataService
+{
+  private readonly string _networkIP;
+  private readonly string? _clusterName;
+
+  public string NetworkIP => _networkIP;
+  public string? ClusterName => _clusterName;
+
+  public MetadataService()
+  {
+    var execEnvType = GetExecEnvType();
+
+    if (execEnvType == ExecEnvType.Local)
+    {
+      _networkIP = "127.0.0.1";
+      _clusterName = null;
+      return;
+    }
+    else if (execEnvType == ExecEnvType.ECS)
+    {
+      // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
+      var _client = new HttpClient();
+      using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+      var response = _client.GetStringAsync(Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4"), cts.Token).GetAwaiter().GetResult();
+      var metadata = JsonDocument.Parse(response).RootElement;
+
+      // ECS response
+      var networks = metadata.GetProperty("Networks");
+      foreach (var network in networks.EnumerateArray())
+      {
+        if (network.GetProperty("NetworkMode").GetString() == "awsvpc")
+        {
+          _networkIP = network.GetProperty("IPv4Addresses").EnumerateArray().First().GetString();
+          break;
+        }
+      }
+
+      var taskArnParts = metadata.GetProperty("TaskARN").GetString().Split('/');
+      _clusterName = taskArnParts.Length > 1 ? taskArnParts[1] : "";
+    }
+    else if (execEnvType == ExecEnvType.EC2)
+    {
+      // Running on EC2
+      _networkIP = EC2InstanceMetadata.NetworkInterfaces.First().LocalIPv4s.First();
+      _clusterName = null;
+    }
+
+    if (_networkIP == null)
+    {
+      throw new ApplicationException("Failed to find awsvpc network");
+    }
+  }
+
+  private enum ExecEnvType
+  {
+    EC2,
+    ECS,
+    Local
+  }
+
+  private static ExecEnvType GetExecEnvType()
+  {
+    var AWS_EXECUTION_ENV = Environment.GetEnvironmentVariable("AWS_EXECUTION_ENV");
+    if (AWS_EXECUTION_ENV == null)
+    {
+      return ExecEnvType.Local;
+    }
+
+    // TODO: Add EKS check
+
+    return AWS_EXECUTION_ENV.StartsWith("AWS_ECS") ? ExecEnvType.ECS : ExecEnvType.EC2;
+  }
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/MetadataService.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/MetadataService.cs
@@ -17,7 +17,7 @@ public class MetadataService : IMetadataService
   public string NetworkIP => _networkIP;
   public string? ClusterName => _clusterName;
 
-  public MetadataService()
+  public MetadataService(IHttpClientFactory? httpClientFactory = null)
   {
     var execEnvType = GetExecEnvType();
 
@@ -30,7 +30,7 @@ public class MetadataService : IMetadataService
     else if (execEnvType == ExecEnvType.ECS)
     {
       // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
-      var _client = new HttpClient();
+      var _client = httpClientFactory != null ? httpClientFactory.CreateClient() : new HttpClient();
       using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
       var response = _client.GetStringAsync(Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4"), cts.Token).GetAwaiter().GetResult();
       var metadata = JsonDocument.Parse(response).RootElement;

--- a/src/PwrDrvr.LambdaDispatch.Router/PwrDrvr.LambdaDispatch.Router.csproj
+++ b/src/PwrDrvr.LambdaDispatch.Router/PwrDrvr.LambdaDispatch.Router.csproj
@@ -17,9 +17,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amazon.CloudWatch.EMF" Version="2.2.0" />
     <PackageReference Include="App.Metrics" Version="4.3.0" />
     <PackageReference Include="App.Metrics.Reporting.Console" Version="4.3.0" />
+    <PackageReference Include="AWS.Lambda.PowerTools.Metrics" Version="1.5.3" />
     <PackageReference Include="AWS.Logger.AspNetCore" Version="3.4.1" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.302.8" />
     <PackageReference Include="AWSSDK.Lambda" Version="3.7.303.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />

--- a/src/PwrDrvr.LambdaDispatch.Router/PwrDrvr.LambdaDispatch.Router.csproj
+++ b/src/PwrDrvr.LambdaDispatch.Router/PwrDrvr.LambdaDispatch.Router.csproj
@@ -17,10 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CloudWatch.EMF" Version="2.2.0" />
     <PackageReference Include="App.Metrics" Version="4.3.0" />
     <PackageReference Include="App.Metrics.Reporting.Console" Version="4.3.0" />
-    <PackageReference Include="AWS.Lambda.PowerTools.Metrics" Version="1.5.3" />
     <PackageReference Include="AWS.Logger.AspNetCore" Version="3.4.1" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.302.8" />
     <PackageReference Include="AWSSDK.Lambda" Version="3.7.303.8" />

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/ConfigTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/ConfigTests.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
 using Moq;
 using Microsoft.Extensions.Configuration;
-using PwrDrvr.LambdaDispatch.Router;
 
 namespace PwrDrvr.LambdaDispatch.Router.Tests;
 

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
@@ -36,6 +36,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       request.Setup(i => i.HttpContext).Returns(requestContext.Object);
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
 
+      GetCallbackIP.Init(1000, "https", "127.0.0.1");
+
       // Start the Lambda
       instance.Start();
 
@@ -89,7 +91,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
     }
 
     [Test]
-    public async Task AddConnection_ShouldHideSurplusConnections()
+    public void AddConnection_ShouldHideSurplusConnections()
     {
       var maxConcurrentCount = 10;
       var lambdaClient = new Mock<IAmazonLambda>();
@@ -100,6 +102,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
       request.Setup(i => i.HttpContext).Returns(requestContext.Object);
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
+
+      GetCallbackIP.Init(1000, "https", "127.0.0.1");
 
       // Start the Lambda
       instance.Start();
@@ -148,7 +152,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
     }
 
     [Test]
-    public async Task AddConnection_ImmediateDispatchShouldCountAsOutstanding()
+    public void AddConnection_ImmediateDispatchShouldCountAsOutstanding()
     {
       var maxConcurrentCount = 10;
       var lambdaClient = new Mock<IAmazonLambda>();
@@ -159,6 +163,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
       request.Setup(i => i.HttpContext).Returns(requestContext.Object);
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
+
+      GetCallbackIP.Init(1000, "https", "127.0.0.1");
 
       // Start the Lambda
       instance.Start();
@@ -188,6 +194,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
       request.Setup(i => i.HttpContext).Returns(requestContext.Object);
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
+
+      GetCallbackIP.Init(1000, "https", "127.0.0.1");
 
       // Start the Lambda
       instance.Start();

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
@@ -37,7 +37,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
 
       // Start the Lambda
-      await instance.Start();
+      instance.Start();
 
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
@@ -102,7 +102,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
 
       // Start the Lambda
-      await instance.Start();
+      instance.Start();
 
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
@@ -161,7 +161,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
 
       // Start the Lambda
-      await instance.Start();
+      instance.Start();
 
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
@@ -190,7 +190,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
 
       // Start the Lambda
-      await instance.Start();
+      instance.Start();
 
       await instance.AddConnection(request.Object, response.Object, "channel-1", false);
 

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
@@ -52,7 +52,11 @@ public class MockHttpMessageHandler : HttpMessageHandler
     // Set the content of the response message based on the request URL
     if (request.RequestUri.ToString() == Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4"))
     {
-      responseMessage.Content = new StringContent("{ \"Networks\": [ { \"NetworkMode\": \"awsvpc\", \"IPv4Addresses\": [ \"192.168.0.1\" ] } ], \"TaskARN\": \"arn:aws:ecs:us-west-2:123456789012:task/test_cluster/abcdefg\" }");
+      responseMessage.Content = new StringContent("{ \"Networks\": [ { \"NetworkMode\": \"awsvpc\", \"IPv4Addresses\": [ \"192.168.0.1\" ] } ] }");
+    }
+    if (request.RequestUri.ToString() == $"{Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4")}/task")
+    {
+      responseMessage.Content = new StringContent("{ \"TaskARN\": \"arn:aws:ecs:us-west-2:123456789012:task/test_cluster/abcdefg\" }");
     }
 
     return await Task.FromResult(responseMessage);

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
@@ -1,0 +1,60 @@
+using Moq;
+using System.Net;
+
+namespace PwrDrvr.LambdaDispatch.Router.Tests;
+
+[TestFixture]
+public class MetadataServiceTests
+{
+  private Mock<IHttpClientFactory> _httpClientFactoryMock;
+  private HttpClient _client;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+    _client = new HttpClient(new MockHttpMessageHandler());
+    _httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(_client);
+  }
+
+  [Test]
+  public void Test_Local_ExecEnvType()
+  {
+    Environment.SetEnvironmentVariable("AWS_EXECUTION_ENV", null);
+    var service = new MetadataService(_httpClientFactoryMock.Object);
+    Assert.Multiple(() =>
+   {
+     Assert.That(service.NetworkIP, Is.EqualTo("127.0.0.1"));
+     Assert.That(service.ClusterName, Is.Null);
+   });
+  }
+
+  [Test]
+  public void Test_ECS_ExecEnvType()
+  {
+    Environment.SetEnvironmentVariable("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE");
+    Environment.SetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4", "http://localhost:1000/v4/metadata");
+    var service = new MetadataService(_httpClientFactoryMock.Object);
+    Assert.Multiple(() =>
+    {
+      Assert.That(service.NetworkIP, Is.EqualTo("192.168.0.1"));
+      Assert.That(service.ClusterName, Is.EqualTo("test_cluster"));
+    });
+  }
+}
+
+public class MockHttpMessageHandler : HttpMessageHandler
+{
+  protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+  {
+    var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+
+    // Set the content of the response message based on the request URL
+    if (request.RequestUri.ToString() == Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4"))
+    {
+      responseMessage.Content = new StringContent("{ \"Networks\": [ { \"NetworkMode\": \"awsvpc\", \"IPv4Addresses\": [ \"192.168.0.1\" ] } ], \"TaskARN\": \"arn:aws:ecs:us-west-2:123456789012:task/test_cluster/abcdefg\" }");
+    }
+
+    return await Task.FromResult(responseMessage);
+  }
+}


### PR DESCRIPTION
- AWS `MetadataService` class
  - Extend the AWS metadata fetching to support both ECS and EC2 (in theory, not tested yet)
  - Use sync HTTP calls for the AWS metadata calls for ECS (not supported by the AWS SDK directly) since the AWS SDK also makes sync HTTP calls as the metadata endpoint is designed to be very fast
  - Remove layers of async/await that were only needed because the callback IP was loaded async
  - Add support for getting the ECS cluster name, used in the `MetricsLogger` below
- AWS CloudWatch EmbeddedMetricsFormat (EMF) `MetricsLogger` class
   - Add a class that can emit metrics about the timing of every single request
   - Set dimensions for the metrics to include the cluster name
   - Add some initial metrics