### PR TITLE
Issue-124 - Scaling Improvements

### DIFF
--- a/DEVELOPMENT-CURRENT-COMMANDS.md
+++ b/DEVELOPMENT-CURRENT-COMMANDS.md
@@ -1,0 +1,46 @@
+# stress
+
+curl -v http://localhost:5001/ping
+TOKIO_WORKER_THREADS=1 oha -c 20 -z 60s http://127.0.0.1:5001/ping
+k6 run k6/ping-dispatch-local.js
+
+# node
+
+NUMBER_OF_WORKERS=4 node dist/app.cjs
+
+# router
+
+dotnet build -c Release src/PwrDrvr.LambdaDispatch.Router
+
+BUILD_TIME=$(date) GIT_HASH=$(git rev-parse --short HEAD) LAMBDA_DISPATCH_MaxWorkerThreads=2 DOTNET_ThreadPool_UnfairSemaphoreSpinLimit=0 LAMBDA_DISPATCH_InstanceCountMultiplier=4 LAMBDA_DISPATCH_MaxConcurrentCount=20 LAMBDA_DISPATCH_AllowInsecureControlChannel=true LAMBDA_DISPATCH_PreferredControlChannelScheme=http LAMBDA_DISPATCH_FunctionName=dogs AWS_LAMBDA_SERVICE_URL=http://localhost:5051 AWS_REGION=us-east-2 AWS_ACCESS_KEY_ID=test-access-key-id AWS_SECRET_ACCESS_KEY=test-secret-access-key AWS_SESSION_TOKEN=test-session-token src/PwrDrvr.LambdaDispatch.Router/bin/Release/net8.0/PwrDrvr.LambdaDispatch.Router 2>&1 > router.log
+
+# extension
+
+LAMBDA_DISPATCH_RUNTIME=current_thread LAMBDA_DISPATCH_FORCE_DEADLINE=60 AWS_LAMBDA_FUNCTION_VERSION=\$LATEST AWS_LAMBDA_FUNCTION_MEMORY_SIZE=512 AWS_LAMBDA_FUNCTION_NAME=dogs AWS_LAMBDA_RUNTIME_API=localhost:5051 AWS_REGION=us-east-2 AWS_ACCESS_KEY_ID=test-access-key-id AWS_SECRET_ACCESS_KEY=test-secret-access-key AWS_SESSION_TOKEN=test-session-token cargo run --release --bin extension 2>&1 | tee extension.log
+
+# d-router
+
+aws sso login
+
+aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 220761759939.dkr.ecr.us-east-2.amazonaws.com                
+
+docker build --build-arg GIT_HASH=$(git rev-parse --short HEAD) --build-arg BUILD_TIME="$(date)" --file DockerfileRouter -t lambda-dispatch-router . && \
+docker tag lambda-dispatch-router:latest 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-router:latest && \
+docker push 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-router:latest && \
+date
+
+# d-router - fix-scale-down-timer branch
+
+BUILD_TIME=$(date) GIT_HASH=$(git rev-parse --short HEAD) LAMBDA_DISPATCH_MaxWorkerThreads=2 DOTNET_ThreadPool_UnfairSemaphoreSpinLimit=0 LAMBDA_DISPATCH_InstanceCountMultiplier=2 LAMBDA_DISPATCH_MaxConcurrentCount=10 LAMBDA_DISPATCH_AllowInsecureControlChannel=true LAMBDA_DISPATCH_PreferredControlChannelScheme=http LAMBDA_DISPATCH_FunctionName=dogs AWS_LAMBDA_SERVICE_URL=http://localhost:5051 AWS_REGION=us-east-2 AWS_ACCESS_KEY_ID=test-access-key-id AWS_SECRET_ACCESS_KEY=test-secret-access-key AWS_SESSION_TOKEN=test-session-token src/PwrDrvr.LambdaDispatch.Router/bin/Release/net8.0/PwrDrvr.LambdaDispatch.Router 2>&1 > router.log
+
+# d-demoapp
+
+docker build --file DockerfileExtension -t lambda-dispatch-extension . && \
+docker build --file DockerfileLambdaDemoApp -t lambda-dispatch-demo-app . && \
+docker tag lambda-dispatch-demo-app:latest 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-demo-app:latest && \
+docker push 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-demo-app:latest && \
+date
+
+# killall
+
+killall -9 PwrDrvr.LambdaDispatch.Router

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,7 +95,7 @@ aws cloudformation update-stack --stack-name lambda-dispatch-ecr-public --templa
 ```sh
 aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 220761759939.dkr.ecr.us-east-2.amazonaws.com
 
-docker build --file DockerfileRouter -t lambda-dispatch-router . && \
+docker build --build-arg GIT_HASH=$(git rev-parse --short HEAD) --build-arg BUILD_TIME="$(date)" --file DockerfileRouter -t lambda-dispatch-router . && \
 docker tag lambda-dispatch-router:latest 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-router:latest && \
 docker push 220761759939.dkr.ecr.us-east-2.amazonaws.com/lambda-dispatch-router:latest
 ```

--- a/DockerfileRouter
+++ b/DockerfileRouter
@@ -25,6 +25,14 @@ RUN dotnet publish src/PwrDrvr.LambdaDispatch.Router/PwrDrvr.LambdaDispatch.Rout
 # Use the runtime image for ARM64
 FROM amazonlinux:2023
 
+# Declare the build argument with a default value
+ARG GIT_HASH=none
+ARG BUILD_TIME=none
+
+# Set the environment variable
+ENV GIT_HASH=$GIT_HASH
+ENV BUILD_TIME=$BUILD_TIME
+
 # Set the working directory
 WORKDIR /app
 

--- a/extension/src/app_start.rs
+++ b/extension/src/app_start.rs
@@ -12,7 +12,7 @@ pub async fn health_check_contained_app(goaway_received: Arc<AtomicBool>) {
   let app_port = app_url.port_u16().unwrap_or(80);
   let app_addr = format!("{}:{}", app_host, app_port);
 
-  while goaway_received.load(std::sync::atomic::Ordering::Relaxed) == false {
+  while goaway_received.load(std::sync::atomic::Ordering::Acquire) == false {
     // Delay 10 ms
     tokio::time::sleep(Duration::from_millis(10)).await;
 

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -30,33 +30,56 @@ pub async fn send_ping_requests(
   host: String,
   port: u16,
   deadline_ms: u64,
-  cancel_sleep: tokio_util::sync::CancellationToken,
+  cancel_token: tokio_util::sync::CancellationToken,
   requests_in_flight: Arc<AtomicUsize>,
 ) {
-  while goaway_received.load(std::sync::atomic::Ordering::Relaxed) == false {
-    let last_active_grace_period_ms = 5000;
+  let start_time = time::current_time_millis();
+  let mut last_ping_time = start_time.clone();
+
+  while goaway_received.load(std::sync::atomic::Ordering::Acquire) == false
+    && cancel_token.is_cancelled() == false
+  {
+    let last_active_grace_period_ms = 250;
     let close_before_deadline_ms = 15000;
-    let last_active_ago_ms = time::current_time_millis() - last_active.load(Ordering::Relaxed);
+    let last_active = last_active.load(Ordering::Acquire);
+    let last_active_ago_ms = if last_active == 0 {
+      0
+    } else {
+      time::current_time_millis() - last_active
+    };
+
+    // Compute stats for log messages
+    let lambda_id = lambda_id.clone();
+    let count = count.load(Ordering::Acquire);
+    let requests_in_flight = requests_in_flight.load(Ordering::Acquire);
+    let elapsed = time::current_time_millis() - start_time;
+    let rps = format!("{:.1}", count as f64 / (elapsed as f64 / 1000.0));
+
     // TODO: Compute time we should stop at based on the initial function timeout duration
-    if last_active_ago_ms > 1 * last_active_grace_period_ms
+    if (last_active != 0
+      && last_active_ago_ms > last_active_grace_period_ms
+      && requests_in_flight == 0)
       || time::current_time_millis() + close_before_deadline_ms > deadline_ms
     {
       if last_active_ago_ms > 1 * last_active_grace_period_ms {
         log::info!(
-          "LambdaId: {}, Last Active: {} ms ago, Reqs in Flight: {} - Requesting close",
-          lambda_id.clone(),
+          "LambdaId: {}, Last Active: {} ms ago, Reqs in Flight: {}, Elapsed: {} ms, RPS: {} - Requesting close: Last Active",
+          lambda_id,
           last_active_ago_ms,
-          requests_in_flight.load(Ordering::Relaxed)
+          requests_in_flight,
+          elapsed,
+          rps
         );
       } else if time::current_time_millis() + close_before_deadline_ms > deadline_ms {
         log::info!(
-          "LambdaId: {}, Deadline: {} ms Away, Reqs in Flight: {} - Requesting close",
-          lambda_id.clone(),
+          "LambdaId: {}, Deadline: {} ms Away, Reqs in Flight: {}, Elapsed: {} ms, RPS: {} - Requesting close: Deadline",
+          lambda_id,
           deadline_ms - time::current_time_millis(),
-          requests_in_flight.load(Ordering::Relaxed)
+          requests_in_flight,
+          elapsed,
+          rps
         );
       }
-      goaway_received.store(true, Ordering::Relaxed);
 
       // Send Close request to router
       let close_url = format!(
@@ -78,6 +101,8 @@ pub async fn send_ping_requests(
         .await
         .is_err()
       {
+        goaway_received.store(true, Ordering::Release);
+
         // This gets hit when the connection for HTTP/1.1 faults
         panic!(
           "Ping Loop - Router connection ready check threw error - connection has disconnected, should reconnect"
@@ -99,106 +124,122 @@ pub async fn send_ping_requests(
         Err(err) => {
           log::error!(
             "LambdaId: {} - PingLoop - Close request failed: {:?}",
-            lambda_id.clone(),
+            lambda_id,
             err
           );
         }
       }
 
+      // Now mark that we are going away, after router has responded to our close request
+      goaway_received.store(true, Ordering::Release);
       break;
     }
 
-    // Send a ping request
-    let ping_url = format!(
-      "{}://{}:{}/api/chunked/ping/{}",
-      scheme, host, port, lambda_id
-    );
-    let (mut ping_tx, ping_recv) = mpsc::channel::<Result<Frame<Bytes>>>(1);
-    let boxed_ping_body = BodyExt::boxed(StreamBody::new(ping_recv));
-    let ping_req = Request::builder()
-      .uri(&ping_url)
-      .method("GET")
-      .header(hyper::header::DATE, fmt_http_date(SystemTime::now()))
-      .header(hyper::header::HOST, authority.as_str())
-      .header("X-Lambda-Id", lambda_id.to_string())
-      .body(boxed_ping_body)
-      .unwrap();
+    // Send a ping request after we have initialized
+    if last_active > 0 && (time::current_time_millis() - last_ping_time) >= 5000 {
+      last_ping_time = time::current_time_millis();
 
-    while futures::future::poll_fn(|ctx| sender.poll_ready(ctx))
-      .await
-      .is_err()
-    {
-      // This gets hit when the connection faults
-      panic!("LambdaId: {} - Ping Loop - Connection ready check threw error - connection has disconnected, should reconnect", lambda_id.clone());
-    }
+      let ping_url = format!(
+        "{}://{}:{}/api/chunked/ping/{}",
+        scheme, host, port, lambda_id
+      );
+      let (mut ping_tx, ping_recv) = mpsc::channel::<Result<Frame<Bytes>>>(1);
+      let boxed_ping_body = BodyExt::boxed(StreamBody::new(ping_recv));
+      let ping_req = Request::builder()
+        .uri(&ping_url)
+        .method("GET")
+        .header(hyper::header::DATE, fmt_http_date(SystemTime::now()))
+        .header(hyper::header::HOST, authority.as_str())
+        .header("X-Lambda-Id", lambda_id.to_string())
+        .body(boxed_ping_body)
+        .unwrap();
 
-    let res = sender.send_request(ping_req).await;
-    ping_tx.close().await.unwrap();
-    match res {
-      Ok(res) => {
-        let (parts, mut res_stream) = res.into_parts();
+      while futures::future::poll_fn(|ctx| sender.poll_ready(ctx))
+        .await
+        .is_err()
+      {
+        // This gets hit when the connection faults
+        panic!("LambdaId: {} - Ping Loop - Connection ready check threw error - connection has disconnected, should reconnect", lambda_id);
+      }
 
-        // Rip through and discard so the response stream is closed
-        while let Some(_chunk) =
-          futures::future::poll_fn(|cx| Incoming::poll_frame(Pin::new(&mut res_stream), cx)).await
-        {
+      let res = sender.send_request(ping_req).await;
+      ping_tx.close().await.unwrap();
+      match res {
+        Ok(res) => {
+          let (parts, mut res_stream) = res.into_parts();
+
+          // Rip through and discard so the response stream is closed
+          while let Some(_chunk) =
+            futures::future::poll_fn(|cx| Incoming::poll_frame(Pin::new(&mut res_stream), cx)).await
+          {
+          }
+
+          if parts.status == 409 {
+            log::info!(
+              "LambdaId: {} - Ping Loop - 409 received on ping, exiting",
+              lambda_id
+            );
+            goaway_received.store(true, Ordering::Release);
+            break;
+          }
+
+          if parts.status != StatusCode::OK {
+            log::info!(
+              "LambdaId: {} - Ping Loop - non-200 received on ping, exiting: {:?}",
+              lambda_id,
+              parts.status
+            );
+            goaway_received.store(true, Ordering::Release);
+            break;
+          }
         }
-
-        if parts.status == 409 {
-          log::info!(
-            "LambdaId: {} - Ping Loop - 409 received on ping, exiting",
-            lambda_id.clone()
+        Err(err) => {
+          log::error!(
+            "LambdaId: {} - Ping Loop - Ping request failed: {:?}",
+            lambda_id,
+            err
           );
-          goaway_received.store(true, Ordering::Relaxed);
-          break;
-        }
-
-        if parts.status != StatusCode::OK {
-          log::info!(
-            "LambdaId: {} - Ping Loop - non-200 received on ping, exiting: {:?}",
-            lambda_id.clone(),
-            parts.status
-          );
-          goaway_received.store(true, Ordering::Relaxed);
-          break;
+          goaway_received.store(true, Ordering::Release);
         }
       }
-      Err(err) => {
-        log::error!(
-          "LambdaId: {} - Ping Loop - Ping request failed: {:?}",
-          lambda_id.clone(),
-          err
-        );
-        goaway_received.store(true, Ordering::Relaxed);
-      }
-    }
 
-    log::info!(
-      "LambdaId: {}, Requests: {}, GoAway: {}, Reqs in Flight: {} - Ping Loop - Looping",
-      lambda_id,
-      count.load(Ordering::Relaxed),
-      goaway_received.load(Ordering::Relaxed),
-      requests_in_flight.load(Ordering::Relaxed)
-    );
+      log::info!(
+        "LambdaId: {}, Requests: {}, GoAway: {}, Reqs in Flight: {}, Elapsed: {} ms, RPS: {} - Ping Loop - Looping",
+        lambda_id,
+        count,
+        goaway_received.load(Ordering::Acquire),
+        requests_in_flight,
+        elapsed,
+        rps
+      );
+    }
 
     tokio::select! {
-        _ = cancel_sleep.cancelled() => {
+        _ = cancel_token.cancelled() => {
           // The token was cancelled
-          log::info!("LambdaId: {}, Reqs in Flight: {} - Ping Loop - Cancelled",
-            lambda_id.clone(),
-            requests_in_flight.load(Ordering::Relaxed)
+          log::info!("LambdaId: {}, Requests: {}, GoAway: {}, Reqs in Flight: {}, Elapsed: {} ms, RPS: {} - Ping Loop - Cancelled",
+            lambda_id,
+            count,
+            goaway_received.load(Ordering::Acquire),
+            requests_in_flight,
+            elapsed,
+            rps
           );
         }
-        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+        _ = tokio::time::sleep(Duration::from_millis(100)) => {
         }
     };
   }
 
+  let count = count.load(Ordering::Acquire);
+  let elapsed = time::current_time_millis() - start_time;
   log::info!(
-    "LambdaId: {}, Requests: {}, GoAway: {}, Reqs in Flight: {} - Ping Loop - Exiting",
+    "LambdaId: {}, Requests: {}, GoAway: {}, Reqs in Flight: {}, Elapsed: {} ms, RPS: {} - Ping Loop - Exiting",
     lambda_id,
-    count.load(Ordering::Relaxed),
-    goaway_received.load(Ordering::Relaxed),
-    requests_in_flight.load(Ordering::Relaxed)
+    count,
+    goaway_received.load(Ordering::Acquire),
+    requests_in_flight.load(Ordering::Acquire),
+    elapsed,
+    format!("{:.1}", count as f64 / (elapsed as f64 / 1000.0))
   );
 }

--- a/k6/ping-dispatch-local-scale-in.js
+++ b/k6/ping-dispatch-local-scale-in.js
@@ -1,0 +1,26 @@
+import http from "k6/http";
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    dispatch: {
+      executor: "ramping-arrival-rate",
+      preAllocatedVUs: 10,
+      maxVUs: 1000,
+      startRate: 20,
+      timeUnit: "1s",
+      stages: [
+        { target: 10000, duration: "10s" },
+        { target: 10000, duration: "10s" },
+        { target: 1000, duration: "10s" },
+        { target: 1000, duration: "2m" },
+        { target: 0, duration: "0" },
+      ],
+      exec: "dispatch",
+    },
+  },
+};
+
+export function dispatch() {
+  http.get("http://127.0.0.1:5001/ping");
+}

--- a/k6/ping-dispatch-local.js
+++ b/k6/ping-dispatch-local.js
@@ -1,0 +1,38 @@
+import http from "k6/http";
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    dispatch: {
+      executor: "ramping-arrival-rate",
+      preAllocatedVUs: 10,
+      maxVUs: 1000,
+      startRate: 20,
+      timeUnit: "1s",
+      stages: [
+        // { target: 1, duration: "10s" },
+        { target: 10, duration: "10s" },
+        { target: 10000, duration: "60s" },
+        { target: 10000, duration: "5m" },
+        // { target: 2000, duration: "60s" },
+        // { target: 2000, duration: "5m" },
+        // { target: 3000, duration: "60s" },
+        // { target: 3000, duration: "5m" },
+        { target: 0, duration: "0" },
+      ],
+      exec: "dispatch",
+    },
+  },
+};
+
+//
+// Reads a random ~1.5 KB record out of DynamoDB
+// This is very fast and a very small response size
+// This is essentially the worst case scenario for lambda dispatch
+// This also contains a 50 ms sleep in the `/read` handler to simulate calling an upstream that takes longer
+// This mean that the CPU on Lambda Dispatch will be underutilized unless
+// the number of concurrent requests is quite high
+//
+export function dispatch() {
+  http.get("http://127.0.0.1:5001/ping");
+}

--- a/k6/ping-dispatch-steady.js
+++ b/k6/ping-dispatch-steady.js
@@ -1,0 +1,38 @@
+import http from "k6/http";
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    dispatch: {
+      executor: "ramping-arrival-rate",
+      preAllocatedVUs: 10,
+      maxVUs: 1000,
+      startRate: 20,
+      timeUnit: "1s",
+      stages: [
+        { target: 1, duration: "10s" },
+        { target: 10, duration: "20s" },
+        { target: 1000, duration: "60s" },
+        { target: 1000, duration: "5m" },
+        { target: 2000, duration: "60s" },
+        { target: 2000, duration: "5m" },
+        { target: 3000, duration: "60s" },
+        { target: 3000, duration: "5m" },
+        { target: 0, duration: "0" },
+      ],
+      exec: "dispatch",
+    },
+  },
+};
+
+//
+// Reads a random ~1.5 KB record out of DynamoDB
+// This is very fast and a very small response size
+// This is essentially the worst case scenario for lambda dispatch
+// This also contains a 50 ms sleep in the `/read` handler to simulate calling an upstream that takes longer
+// This mean that the CPU on Lambda Dispatch will be underutilized unless
+// the number of concurrent requests is quite high
+//
+export function dispatch() {
+  http.get("http://127.0.0.1:5001/ping");
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/CapacityManager.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/CapacityManager.cs
@@ -1,0 +1,88 @@
+namespace PwrDrvr.LambdaDispatch.Router;
+
+public class CapacityManager(int maxConcurrentCount, int instanceCountMultiplier)
+{
+  private readonly int _maxConcurrentCount = maxConcurrentCount;
+  private readonly int _instanceCountMultiplier = instanceCountMultiplier;
+  private readonly int _targetConcurrentRequestsPerInstance
+    = (int)Math.Ceiling((double)maxConcurrentCount / instanceCountMultiplier);
+
+  /// <summary>
+  /// Calculate the desired instance count based on the number of pending and running requests
+  /// </summary>
+  /// <param name="pendingRequests"></param>
+  /// <param name="runningRequests"></param>
+  /// <returns></returns>
+  public int SimpleDesiredInstanceCount(int pendingRequests, int runningRequests)
+  {
+    // Calculate the desired count
+    var cleanPendingRequests = Math.Max(pendingRequests, 0);
+    var cleanRunningRequests = Math.Max(runningRequests, 0);
+
+    // Special case for 0 pending or running requests
+    if (cleanPendingRequests == 0 && cleanRunningRequests == 0)
+    {
+      return 0;
+    }
+
+    // Calculate the desired count
+    // We have to have enough capacity for the currently running requests
+    // For running requests we want to try to keep the instances at their target concurrent requests
+    var requiredRunningCount
+      = (double)cleanRunningRequests / _targetConcurrentRequestsPerInstance;
+
+    // We want to be able to dispatch a portion of the pending requests
+    // For pending requests, the dispacher will chew up all the connections, not just the target ones
+    // Thus we scale based on the total connections for pending not the target
+    // If we really start building a queue the EWMA scaler will kick in
+    // Also as these shift over to running they will cause further scale up if they stick around
+    var pendingDispatchCount
+      = (double)cleanPendingRequests / _maxConcurrentCount * .5;
+
+    return (int)Math.Ceiling(requiredRunningCount + pendingDispatchCount);
+  }
+
+  public int EwmaDesiredInstanceCount(double requestsPerSecondEWMA, double requestDurationEWMA)
+  {
+    double requestsPerSecondPerLambda
+      = 1000 / Math.Max(2, requestDurationEWMA) * _targetConcurrentRequestsPerInstance;
+
+    var ewmaScalerDesiredInstanceCount
+      = (int)Math.Ceiling(requestsPerSecondEWMA / requestsPerSecondPerLambda);
+
+    return ewmaScalerDesiredInstanceCount;
+  }
+
+  public int ConstrainDesiredInstanceCount(int proposedDesiredInstanceCount, int currentDesiredInstanceCount,
+    int maxScaleOut, double maxScaleOutRatio, double maxScaleInRatio)
+  {
+    // Calculate the maximum allowed change
+    int maxScaleOutChange
+      = Math.Max(maxScaleOut, (int)Math.Ceiling(currentDesiredInstanceCount * maxScaleOutRatio));
+    int maxScaleInChange
+      = Math.Max(maxScaleOut, (int)Math.Ceiling(currentDesiredInstanceCount * maxScaleInRatio));
+
+    // We always allow scaling to 0
+    if (proposedDesiredInstanceCount == 0)
+    {
+      return 0;
+    }
+
+    // Calculate the proposed change
+    int proposedChange = proposedDesiredInstanceCount - currentDesiredInstanceCount;
+
+    // If the proposed change is greater than the maximum allowed change, adjust proposedDesiredInstanceCount
+    if (proposedChange > maxScaleOutChange)
+    {
+      proposedDesiredInstanceCount = currentDesiredInstanceCount + maxScaleOutChange;
+    }
+
+    // If the proposed change is less than the negative of the maximum allowed change, adjust proposedDesiredInstanceCount
+    if (proposedChange < -maxScaleInChange)
+    {
+      proposedDesiredInstanceCount = currentDesiredInstanceCount - maxScaleInChange;
+    }
+
+    return proposedDesiredInstanceCount;
+  }
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/Config.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Config.cs
@@ -163,6 +163,15 @@ public class Config : IConfig
       throw new ApplicationException($"Invalid PreferredControlChannelScheme in configuration: {PreferredControlChannelScheme}");
     }
 
+    if (MaxConcurrentCount < 1)
+    {
+      throw new ApplicationException($"Invalid MaxConcurrentCount in configuration, must be >= 1: {MaxConcurrentCount}");
+    }
+    if (MaxConcurrentCount > 100)
+    {
+      throw new ApplicationException($"Invalid MaxConcurrentCount in configuration, must be < 100: {MaxConcurrentCount}");
+    }
+
     // Need at least as many channels as max concurrent
     if (ChannelCount == -1)
     {

--- a/src/PwrDrvr.LambdaDispatch.Router/Dispatcher.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Dispatcher.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
-using System.Threading.Channels;
+using System.Diagnostics;
+using PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
 
 namespace PwrDrvr.LambdaDispatch.Router;
 
@@ -11,38 +12,13 @@ public class DispatcherAddConnectionResult
   public bool LambdaIDNotFound { get; set; } = false;
 }
 
-public class PendingRequest
-{
-  public HttpRequest Request { get; set; }
-  public HttpResponse Response { get; set; }
-  public TaskCompletionSource ResponseFinishedTCS { get; set; } = new TaskCompletionSource();
-  public DateTime CreationTime { get; }
-
-  public DateTime DispatchTime { get; private set; }
-
-  public void RecordDispatchTime()
-  {
-    DispatchTime = DateTime.Now;
-  }
-
-  public TimeSpan Duration => DispatchTime - CreationTime;
-
-  public PendingRequest(HttpRequest request, HttpResponse response)
-  {
-    Request = request;
-    Response = response;
-    CreationTime = DateTime.Now;
-    DispatchTime = DateTime.Now;
-  }
-}
-
 /// <summary>
 /// Exposes only the background dispatch function needed by
 /// instances when a request completes
 /// </summary>
 public interface IBackgroundDispatcher
 {
-  Task<bool> TryBackgroundDispatchOne(bool countAsForeground = false);
+  void WakeupBackgroundDispatcher(LambdaConnection? connection);
 }
 
 public class Dispatcher : IBackgroundDispatcher
@@ -51,27 +27,48 @@ public class Dispatcher : IBackgroundDispatcher
 
   private readonly ILambdaInstanceManager _lambdaInstanceManager;
 
+  private readonly IMetricsLogger _metricsLogger;
+
+  private readonly WeightedAverage _incomingRequestsWeightedAverage = new(15);
+
+  // NOTE: Microseconds since this can only store longs
+  private readonly WeightedAverage _incomingRequestDurationAverage = new(15, mean: true);
+
   // Requests that are waiting to be dispatched to a Lambda
   private volatile int _pendingRequestCount = 0;
-  private readonly ConcurrentQueue<PendingRequest> _pendingRequests = new();
 
-  private readonly Channel<int> _pendingRequestSignal = Channel.CreateBounded<int>(new BoundedChannelOptions(1)
-  {
-    FullMode = BoundedChannelFullMode.DropOldest,
-  });
+  /// <summary>
+  /// Requests that are waiting for a connection
+  /// </summary>
+  private readonly BlockingCollection<PendingRequest> _pendingRequests = [];
+
+  /// <summary>
+  /// All connections in this queue should be available for use, marked as in use, but not yet confirmed
+  /// to be used.
+  /// 
+  /// The background dispatcher will pick these up and either use them or add them to the LOQ using
+  /// ReenqueueUnusedConnection() in that case.
+  /// </summary>
+  private readonly BlockingCollection<LambdaConnection?> _newConnections = [];
+
+  private readonly IShutdownSignal _shutdownSignal;
 
   // We need to keep a count of the running requests so we can set the desired count
   private volatile int _runningRequestCount = 0;
 
-  public Dispatcher(ILogger<Dispatcher> logger, ILambdaInstanceManager lambdaInstanceManager)
+  public Dispatcher(ILogger<Dispatcher> logger, IMetricsLogger metricsLogger, ILambdaInstanceManager lambdaInstanceManager, IShutdownSignal shutdownSignal)
   {
     _logger = logger;
+    _metricsLogger = metricsLogger;
     _logger.LogDebug("Dispatcher created");
     _lambdaInstanceManager = lambdaInstanceManager;
+    _shutdownSignal = shutdownSignal;
     _lambdaInstanceManager.AddBackgroundDispatcherReference(this);
 
     // Start the background task to process pending requests
-    Task.Run(BackgroundPendingRequestDispatcher);
+    // This needs it's own thread because BlockingCollection will block the thread
+    // and we don't want to block a ThreadPool worker thread (which we are limiting)
+    new Thread(BackgroundPendingRequestDispatcher).Start();
   }
 
   public bool PingInstance(string instanceId)
@@ -83,9 +80,12 @@ public class Dispatcher : IBackgroundDispatcher
     return found;
   }
 
-  public void CloseInstance(string instanceId)
+  public async Task CloseInstance(string instanceId, bool lambdaInitiated = false)
   {
-    _lambdaInstanceManager.CloseInstance(instanceId);
+    if (_lambdaInstanceManager.ValidateLambdaId(instanceId, out var instance))
+    {
+      await _lambdaInstanceManager.CloseInstance(instance, lambdaInitiated);
+    }
   }
 
   // Add a new request, dispatch immediately if able
@@ -94,29 +94,71 @@ public class Dispatcher : IBackgroundDispatcher
     _logger.LogDebug("Adding request to the Dispatcher");
 
     MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.RequestCount);
+    MetricsRegistry.Metrics.Measure.Meter.Mark(MetricsRegistry.IncomingRequestsMeter, 1);
+    _incomingRequestsWeightedAverage.Add();
+    MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.IncomingRequestRPS, _incomingRequestsWeightedAverage.EWMA);
 
-    // If no queue and idle lambdas, try to get an idle lambda and dispatch immediately
-    if (_pendingRequestCount == 0 && _lambdaInstanceManager.TryGetConnection(out var lambdaConnection))
+    // If idle lambdas, try to get an idle lambda and dispatch immediately
+    // If there is a queue, they are going to see the new connections before us anyway
+    // If we get a connection from the queue, it's fair game
+    if (_lambdaInstanceManager.TryGetConnection(out var lambdaConnection, tentative: false))
     {
+      var sw = Stopwatch.StartNew();
       _logger.LogDebug("Dispatching incoming request immediately to LambdaId: {Id}", lambdaConnection.Instance.Id);
 
       MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.ImmediateDispatchCount);
       MetricsRegistry.Metrics.Measure.Histogram.Update(MetricsRegistry.DispatchDelay, 0);
+      _metricsLogger.PutMetric("DispatchDelay", 0, Unit.Milliseconds);
 
       Interlocked.Increment(ref _runningRequestCount);
       MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.RunningRequests);
 
+      // Tell the scaler we're running more requests now
+      _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount, _incomingRequestsWeightedAverage.EWMA, _incomingRequestDurationAverage.EWMA / 1000);
+
       try
       {
         await lambdaConnection.RunRequest(incomingRequest, incomingResponse).ConfigureAwait(false);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Dispatcher.AddRequest - Exception while running request");
+        try
+        {
+          incomingResponse.ContentType = "text/plain";
+          incomingResponse.Headers.Append("Server", "PwrDrvr.LambdaDispatch.Router");
+
+          if (ex is TimeoutException)
+          {
+            incomingResponse.StatusCode = StatusCodes.Status504GatewayTimeout;
+            await incomingResponse.WriteAsync("Gateway timeout");
+          }
+          else
+          {
+            incomingResponse.StatusCode = StatusCodes.Status502BadGateway;
+            await incomingResponse.WriteAsync("Bad gateway");
+          }
+        }
+        catch
+        {
+          // This can throw if the request/response have already been sent/aborted
+          try { incomingResponse.HttpContext.Abort(); } catch { }
+        }
       }
       finally
       {
         Interlocked.Decrement(ref _runningRequestCount);
         MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.RunningRequests);
 
-        // Update number of instances that we want
-        await _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount);
+        _incomingRequestDurationAverage.Add((long)sw.Elapsed.TotalMilliseconds * 1000);
+        MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.IncomingRequestDurationEWMA, _incomingRequestDurationAverage.EWMA / 1000);
+        MetricsRegistry.Metrics.Measure.Histogram.Update(MetricsRegistry.IncomingRequestDuration, sw.ElapsedMilliseconds);
+        MetricsRegistry.Metrics.Measure.Histogram.Update(MetricsRegistry.IncomingRequestDurationAfterDispatch, sw.ElapsedMilliseconds);
+        _metricsLogger.PutMetric("IncomingRequestDuration", Math.Round(sw.Elapsed.TotalMilliseconds, 1), Unit.Milliseconds);
+        _metricsLogger.PutMetric("IncomingRequestDurationAfterDispatch", Math.Round(sw.Elapsed.TotalMilliseconds, 1), Unit.Milliseconds);
+
+        // Tell the scaler about the lowered request count
+        _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount, _incomingRequestsWeightedAverage.EWMA, _incomingRequestDurationAverage.EWMA / 1000);
       }
       return;
     }
@@ -126,22 +168,52 @@ public class Dispatcher : IBackgroundDispatcher
     // If there are no idle lambdas, add the request to the pending queue
     // Add the request to the pending queue
     var pendingRequest = new PendingRequest(incomingRequest, incomingResponse);
-    _pendingRequests.Enqueue(pendingRequest);
+    _pendingRequests.Add(pendingRequest);
     Interlocked.Increment(ref _pendingRequestCount);
-    _pendingRequestSignal.Writer.TryWrite(1);
     MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.QueuedRequests);
 
     // Update number of instances that we want
-    await _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount);
+    _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount, _incomingRequestsWeightedAverage.EWMA, _incomingRequestDurationAverage.EWMA / 1000);
 
     // Wait for the request to be dispatched or to timeout
-    // await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(30000));
-    await pendingRequest.ResponseFinishedTCS.Task.WaitAsync(TimeSpan.FromMinutes(5));
+    // TODO: Get this timeout from the config
+    try
+    {
+      //
+      // This waits for the background dispatcher to, maybe, pickup the request
+      //
+      await pendingRequest.ResponseFinishedTCS.Task.WaitAsync(TimeSpan.FromSeconds(120));
+    }
+    catch (Exception ex)
+    {
+      // Mark the request as aborted
+      pendingRequest.Abort();
 
-    MetricsRegistry.Metrics.Measure.Histogram.Update(MetricsRegistry.DispatchDelay, (long)pendingRequest.Duration.TotalMilliseconds);
+      try
+      {
+        incomingResponse.ContentType = "text/plain";
+        incomingResponse.Headers.Append("Server", "PwrDrvr.LambdaDispatch.Router");
+
+        if (ex is TimeoutException)
+        {
+          incomingResponse.StatusCode = StatusCodes.Status504GatewayTimeout;
+          await incomingResponse.WriteAsync("Gateway timeout");
+        }
+        else
+        {
+          incomingResponse.StatusCode = StatusCodes.Status500InternalServerError;
+          await incomingResponse.WriteAsync("Internal server error");
+        }
+      }
+      catch
+      {
+        // This can throw if the request/response have already been sent/aborted
+        try { incomingResponse.HttpContext.Abort(); } catch { }
+      }
+    }
   }
 
-  // Add a new lambda, dispatch to it immediately if a request is waiting
+  // Add a new connection for a lambda, dispatch to it immediately if a request is waiting
   public async Task<DispatcherAddConnectionResult> AddConnectionForLambda(HttpRequest request, HttpResponse response, string lambdaId, string channelId)
   {
     DispatcherAddConnectionResult result = new();
@@ -165,223 +237,279 @@ public class Dispatcher : IBackgroundDispatcher
 
     if (!_lambdaInstanceManager.ValidateLambdaId(lambdaId, out var instance))
     {
-      _logger.LogError("Unknown LambdaId: {lambdaId}, ChannelId: {channelId}", lambdaId, channelId);
+      _logger.LogDebug("Unknown LambdaId: {lambdaId}, ChannelId: {channelId}", lambdaId, channelId);
       result.LambdaIDNotFound = true;
       return result;
     }
 
     // We have a valid connection
     // But, the instance may be at it's outstanding request limit
-    // since we can have more connections then we are allowed to use
+    // since we can have more connections than we are allowed to use
     // Check if we are allowed (race condition, sure) to use this connection
     // Let's try to dispatch if there is a pending request in the queue
     // Get the pending request
-    if (instance.OutstandingRequestCount < instance.MaxConcurrentCount
-        && _pendingRequests.TryDequeue(out var pendingRequest))
+    if (_pendingRequestCount > 0
+        // This connection may be hidden
+        && instance.OutstandingRequestCount < instance.MaxConcurrentCount)
     {
-      _logger.LogDebug("Dispatching pending request to LambdaId: {lambdaId}, ChannelId: {channelId}", lambdaId, channelId);
-      Interlocked.Decrement(ref _pendingRequestCount);
-      MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.QueuedRequests);
-
-      MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.PendingDispatchCount);
-      MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.PendingDispatchForegroundCount);
-
       // Register the connection with the lambda
-      var connection = await _lambdaInstanceManager.AddConnectionForLambda(request, response, lambdaId, channelId, true);
+      var connection = await _lambdaInstanceManager.AddConnectionForLambda(request, response, lambdaId, channelId, AddConnectionDispatchMode.TentativeDispatch);
 
       // If the connection returned is null then the Response has already been disposed
       // This will be null if the Lambda was actually gone when we went to add it to the instance manager
       if (connection == null)
       {
-        _logger.LogError("Failed adding connection to LambdaId {lambdaId} ChannelId {channelId}, putting the request back in the queue", lambdaId, channelId);
-        _pendingRequests.Enqueue(pendingRequest);
-        Interlocked.Increment(ref _pendingRequestCount);
-        _pendingRequestSignal.Writer.TryWrite(1);
-        MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.QueuedRequests);
-        MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.PendingDispatchCount);
-        MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.PendingDispatchForegroundCount);
+        // AddConnectionForLambda returns null if the connection is added but
+        // not suppoed to be used due to being at MaxConcurrentCount
+        _logger.LogDebug("Failed adding connection to LambdaId (happens with hidden connections) {lambdaId} ChannelId {channelId}, putting the request back in the queue", lambdaId, channelId);
         return result;
       }
 
-      // Start the response
-      // This sends the headers
-      await response.StartAsync();
-
-      // Only at this point are we sure we're going to dispatch
-      pendingRequest.RecordDispatchTime();
-      if (pendingRequest.Duration > TimeSpan.FromSeconds(1))
+      if (TryGetPendingRequestAndDispatch(connection))
       {
-        _logger.LogWarning("Dispatching (foreground) pending request that has been waiting for {duration} ms, LambdaId: {lambdaId}, ChannelId: {channelId}", pendingRequest.Duration.TotalMilliseconds, lambdaId, channelId);
-      }
-
-      // Dispatch the request to the lambda
-      Interlocked.Increment(ref _runningRequestCount);
-      MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.RunningRequests);
-      try
-      {
-        await connection.RunRequest(pendingRequest.Request, pendingRequest.Response).ConfigureAwait(false);
-      }
-      finally
-      {
-        Interlocked.Decrement(ref _runningRequestCount);
-        MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.RunningRequests);
-
+        MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.PendingDispatchForegroundCount);
         result.ImmediatelyDispatched = true;
         result.Connection = connection;
-
-        // Signal the pending request that it's been completed
-        pendingRequest.ResponseFinishedTCS.SetResult();
-
-        // Update number of instances that we want
-        await _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount);
+        return result;
       }
 
+      // Have to return here, else connection gets added twice below
+      result.ImmediatelyDispatched = false;
+      result.Connection = connection;
       return result;
     }
 
-    //
-    // There was no pending request to immediately dispatch, so just add the connection
-    //
-    // NOTE: As soon as this is called the connection can be taken and used for a request
-    // we do not own this request/response anymore after this call
-    //
-    result.Connection = await _lambdaInstanceManager.AddConnectionForLambda(request, response, lambdaId, channelId);
+    // Register the connection but keep it private until the background dispatcher handles it
+    result.Connection = await _lambdaInstanceManager.AddConnectionForLambda(request, response, lambdaId, channelId,
+      dispatchMode: AddConnectionDispatchMode.TentativeDispatch);
+
+    if (result.Connection != null)
+    {
+      // Pass the connection through the background dispatcher
+      _newConnections.Add(result.Connection);
+    }
+
+    // Tell the scaler about the number of running instances
+    // Is this needed?
+    if (result.Connection != null && result.Connection.FirstConnectionForInstance)
+    {
+      _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount, _incomingRequestsWeightedAverage.EWMA, _incomingRequestDurationAverage.EWMA / 1000);
+    }
 
     return result;
   }
 
-  private async Task BackgroundPendingRequestDispatcher()
+  /// <summary>
+  /// Passes a connection through the background dispatcher when a Lambda Instance
+  /// sees a completed request that exposes an existing unused / hidden connection
+  /// </summary>
+  /// <param name="lambdaConnection"></param>
+  public void WakeupBackgroundDispatcher(LambdaConnection? lambdaConnection)
   {
+    // Yes, it is a race condition, but it doesn't matter because the
+    // background dispatcher will check it shortly after
+    if (_pendingRequestCount != 0)
+    {
+      _newConnections.Add(lambdaConnection);
+    }
+  }
+
+  /// <summary>
+  /// Dispatch pending requests to Lambdas in the background
+  /// 
+  /// All incoming connections pass through here
+  /// </summary>
+  private void BackgroundPendingRequestDispatcher()
+  {
+    var capacityMessageInterval = TimeSpan.FromMilliseconds(250);
+    var swLastCapacityMessage = Stopwatch.StartNew();
+
     while (true)
     {
-      // Wait for the signal or 1 second
       try
       {
-        // Create a CancellationToken that will be cancelled after 1 second
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-
-        await _pendingRequestSignal.Reader.ReadAsync(cts.Token).ConfigureAwait(false);
-        _logger.LogDebug("BackgroundPendingRequestDispatcher - Got signal");
-
-        // Loop quickly in case we had a race condition on enqueing a pending request
-        // This happens when we have a request and a connection both arrive at the same time
-        // and there are no other available connections.  They both check for the other, find
-        // none, and get put into lists.
-        // If another connection comes in it will pickup this pending request, so we only
-        // have to cover the case of the brief race
-        var tryCount = 0;
-        while (
-          // We have this check here (not just in the called function)
-          // because we want to skip these 10 loops if there are no requests waiting anymore
-          _pendingRequestCount > 0
-          && !await TryBackgroundDispatchOne()
-          && tryCount++ < 10)
+        // This blocks until a connection is available
+        // or the timeout is hit
+        if (_newConnections.TryTake(out var connection, 20, _shutdownSignal.Shutdown.Token) && connection != null)
         {
-          _logger.LogDebug("BackgroundPendingRequestDispatcher - Could not dispatch one, trying again");
+          _logger.LogDebug("BackgroundPendingRequestDispatcher - Got a connection for LambdaId {}, ChannelId {}",
+            connection.Instance.Id, connection.ChannelId);
+          if (TryGetPendingRequestAndDispatch(connection))
+          {
+            MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.PendingDispatchBackgroundCount);
+            swLastCapacityMessage.Restart();
+          }
+        }
+        else
+        {
+          // The LOQ may have a connection if ChannelCount > MaxConcurrentCount
+          // and a response has been completed
+          // We get woken up here when a connection is added to the LOQ, so let's check
+          var anyDispatched = false;
+          while (_lambdaInstanceManager.TryGetConnection(out connection, tentative: true)
+                  && TryGetPendingRequestAndDispatch(connection))
+          {
+            anyDispatched = true;
+            MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.PendingDispatchBackgroundCount);
+          }
 
-          await Task.Delay(TimeSpan.FromMilliseconds(10)).ConfigureAwait(false);
+          if (anyDispatched)
+          {
+            // We dispatched some requests, so we should check the capacity
+            swLastCapacityMessage.Restart();
+          }
+          else if (swLastCapacityMessage.Elapsed > capacityMessageInterval)
+          {
+            MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.IncomingRequestDurationEWMA, _incomingRequestDurationAverage.EWMA / 1000);
+            MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.IncomingRequestRPS, _incomingRequestDurationAverage.EWMA);
+            _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount, _incomingRequestsWeightedAverage.EWMA, _incomingRequestDurationAverage.EWMA / 1000);
+            swLastCapacityMessage.Restart();
+          }
         }
       }
       catch (OperationCanceledException)
       {
-        _logger.LogDebug("BackgroundPendingRequestDispatcher - Timed out");
-
-        // We timed out, so try to dispatch one even though we didn't get a signal
-        if (await TryBackgroundDispatchOne())
-        {
-          _logger.LogDebug("BackgroundPendingRequestDispatcher - Dispatched one");
-        }
+        _logger.LogInformation("BackgroundPendingRequestDispatcher - Exiting Loop");
+        return;
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "BackgroundPendingRequestDispatcher - Exception");
       }
     }
   }
 
   /// <summary>
-  /// Check for a pending request and an available connection
-  /// Match them up if we find them
+  /// Get a pending request and dispatch it to a Lambda
+  ///
+  /// Assumes that the connection is marked for TentativeDispatch
+  /// 
+  /// Re-enqueues the tentative connection if it's not used
+  /// 
+  /// Handles adjusting all counts
+  /// </summary>
+  private bool TryGetPendingRequestAndDispatch(LambdaConnection connection)
+  {
+    var dispatchedRequest = false;
+
+    // Try to dispatch a pending request
+    while (_pendingRequests.TryTake(out var pendingRequest))
+    {
+      // Check if the pending request is already canceled
+      if (pendingRequest.GatewayTimeoutCTS.IsCancellationRequested)
+      {
+        // The pending request at front of queue was canceled, we're removing it
+        Interlocked.Decrement(ref _pendingRequestCount);
+        MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.QueuedRequests);
+        _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount, _incomingRequestsWeightedAverage.EWMA, _incomingRequestDurationAverage.EWMA / 1000);
+
+        // Try to find another request
+        continue;
+      }
+
+      _logger.LogDebug("BackgroundPendingRequestDispatcher - Got a pending request, dispatching to LambdaId {}, ChannelId {}", connection.Instance.Id, connection.ChannelId);
+
+      // We've got a good request and a good connection
+      dispatchedRequest = true;
+      TryBackgroundDispatchOne(pendingRequest, connection);
+      break;
+    }
+
+    // Add the connection to the LOQ since we didn't use it
+    if (!dispatchedRequest)
+    {
+      _logger.LogDebug("BackgroundPendingRequestDispatcher - Reenqueuing unused connection for LambdaId {}, ChannelId {}", connection.Instance.Id, connection.ChannelId);
+      _lambdaInstanceManager.ReenqueueUnusedConnection(connection, connection.Instance.Id);
+    }
+
+    return dispatchedRequest;
+  }
+
+  /// <summary>
+  /// Dispatch a single pending request to a Lambda
+  /// 
+  /// Handles adjusting all counts
   /// </summary>
   /// <returns>Whether a request was dispatched</returns>
-  public async Task<bool> TryBackgroundDispatchOne(bool countAsForeground = false)
+  private bool TryBackgroundDispatchOne(PendingRequest pendingRequest, LambdaConnection lambdaConnection)
   {
     var startedRequest = false;
 
     try
     {
-      // If there should be pending requests, try to get a connection then grab a request
-      // If we can't get a pending request, put the connection back
-      if (_pendingRequestCount > 0)
+      startedRequest = true;
+      pendingRequest.RecordDispatchTime();
+      _logger.LogDebug("Dispatching pending request");
+      MetricsRegistry.Metrics.Measure.Histogram.Update(MetricsRegistry.DispatchDelay, (long)pendingRequest.DispatchDelay.TotalMilliseconds);
+      _metricsLogger.PutMetric("DispatchDelay", Math.Round(pendingRequest.DispatchDelay.TotalMilliseconds, 1), Unit.Milliseconds);
+      if (pendingRequest.DispatchDelay > TimeSpan.FromSeconds(1))
       {
-        // Try to get a connection
-        if (!_lambdaInstanceManager.TryGetConnection(out var lambdaConnection, tentative: true))
-        {
-          _logger.LogDebug("TryBackgroundDispatchOne - No connections available");
-
-          // Start more instances if needed
-          await _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount).ConfigureAwait(false);
-          return false;
-        }
-
-        // Try to get a pending request
-        if (_pendingRequests.TryDequeue(out var pendingRequest))
-        {
-          startedRequest = true;
-          pendingRequest.RecordDispatchTime();
-          _logger.LogDebug("Dispatching pending request");
-
-          if (pendingRequest.Duration > TimeSpan.FromSeconds(1))
-          {
-            _logger.LogWarning("Dispatching (background) pending request that has been waiting for {duration} ms", pendingRequest.Duration.TotalMilliseconds);
-          }
-
-          // Register that we are going to use this connection
-          // This will add the decrement of outstanding connections when complete
-          lambdaConnection.Instance.TryGetConnectionWillUse(lambdaConnection);
-
-          MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.PendingDispatchCount);
-          if (countAsForeground)
-          {
-            MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.PendingDispatchForegroundCount);
-          }
-          else
-          {
-            MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.PendingDispatchBackgroundCount);
-          }
-
-          Interlocked.Decrement(ref _pendingRequestCount);
-          MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.QueuedRequests);
-
-          Interlocked.Increment(ref _runningRequestCount);
-          MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.RunningRequests);
-
-          try
-          {
-            await lambdaConnection.RunRequest(pendingRequest.Request, pendingRequest.Response).ConfigureAwait(false);
-          }
-          finally
-          {
-            Interlocked.Decrement(ref _runningRequestCount);
-            MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.RunningRequests);
-
-            // Signal the pending request that it's been completed
-            pendingRequest.ResponseFinishedTCS.SetResult();
-
-            // Update number of instances that we want
-            await _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount);
-          }
-
-          return true;
-        }
-        else
-        {
-          _logger.LogDebug("TryBackgroundDispatchOne - No pending requests, putting connection back");
-
-          // We didn't get a pending request, so put the connection back
-          await _lambdaInstanceManager.ReenqueueUnusedConnection(lambdaConnection, lambdaConnection.Instance.Id);
-
-          return false;
-        }
+        _logger.LogWarning("Dispatching (background) pending request that has been waiting for {duration} ms", pendingRequest.DispatchDelay.TotalMilliseconds);
       }
 
-      return false;
+      // Register that we are going to use this connection
+      // This will add the decrement of outstanding connections when complete
+      lambdaConnection.Instance.TryGetConnectionWillUse(lambdaConnection);
+
+      MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.PendingDispatchCount);
+
+      Interlocked.Decrement(ref _pendingRequestCount);
+      MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.QueuedRequests);
+
+      Interlocked.Increment(ref _runningRequestCount);
+      MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.RunningRequests);
+
+      // Update number of instances that we want
+      _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount, _incomingRequestsWeightedAverage.EWMA, _incomingRequestDurationAverage.EWMA / 1000);
+
+      // Do not await this, let it loop around
+      _ = lambdaConnection.RunRequest(pendingRequest.Request, pendingRequest.Response).ContinueWith(async Task (task) =>
+      {
+        Interlocked.Decrement(ref _runningRequestCount);
+        MetricsRegistry.Metrics.Measure.Counter.Decrement(MetricsRegistry.RunningRequests);
+
+        // Signal the pending request that it's been completed
+        pendingRequest.ResponseFinishedTCS.SetResult();
+
+        // Record the duration
+        _incomingRequestDurationAverage.Add((long)pendingRequest.Duration.TotalMilliseconds * 1000);
+        MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.IncomingRequestDurationEWMA, _incomingRequestDurationAverage.EWMA / 1000);
+        MetricsRegistry.Metrics.Measure.Histogram.Update(MetricsRegistry.IncomingRequestDuration, (long)pendingRequest.Duration.TotalMilliseconds);
+        MetricsRegistry.Metrics.Measure.Histogram.Update(MetricsRegistry.IncomingRequestDurationAfterDispatch, (long)(pendingRequest.Duration.TotalMilliseconds - pendingRequest.DispatchDelay.TotalMilliseconds));
+        _metricsLogger.PutMetric("IncomingRequestDuration", Math.Round(pendingRequest.Duration.TotalMilliseconds, 1), Unit.Milliseconds);
+        _metricsLogger.PutMetric("IncomingRequestDurationAfterDispatch", Math.Round(pendingRequest.Duration.TotalMilliseconds - pendingRequest.DispatchDelay.TotalMilliseconds, 1), Unit.Milliseconds);
+
+        // Update number of instances that we want
+        _lambdaInstanceManager.UpdateDesiredCapacity(_pendingRequestCount, _runningRequestCount, _incomingRequestsWeightedAverage.EWMA, _incomingRequestDurationAverage.EWMA / 1000);
+
+        // Handle the exception
+        if (task.IsFaulted)
+        {
+          try
+          {
+            pendingRequest.Response.ContentType = "text/plain";
+            pendingRequest.Response.Headers.Append("Server", "PwrDrvr.LambdaDispatch.Router");
+
+            if (task.Exception.InnerExceptions.Any(e => e is TimeoutException))
+            {
+              pendingRequest.Response.StatusCode = StatusCodes.Status504GatewayTimeout;
+              await pendingRequest.Response.WriteAsync("Gateway timeout");
+            }
+            else
+            {
+              pendingRequest.Response.StatusCode = StatusCodes.Status502BadGateway;
+              await pendingRequest.Response.WriteAsync("Bad gateway");
+            }
+          }
+          catch
+          {
+            // This can throw if the request/response have already been sent/aborted
+            try { pendingRequest.Response.HttpContext.Abort(); } catch { }
+          }
+        }
+      }).ConfigureAwait(false);
+
+      return startedRequest;
     }
     catch (Exception ex)
     {

--- a/src/PwrDrvr.LambdaDispatch.Router/IncomingRequestMiddleware.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/IncomingRequestMiddleware.cs
@@ -1,0 +1,37 @@
+namespace PwrDrvr.LambdaDispatch.Router;
+
+public class IncomingRequestMiddleware
+{
+  private readonly RequestDelegate _next;
+  private readonly Dispatcher _dispatcher;
+  private readonly int[] _allowedPorts;
+
+  public IncomingRequestMiddleware(RequestDelegate next, Dispatcher dispatcher, int[] allowedPorts)
+  {
+    _next = next;
+    _dispatcher = dispatcher;
+    _allowedPorts = allowedPorts;
+  }
+
+  public async Task InvokeAsync(HttpContext context)
+  {
+    if (_allowedPorts.Contains(context.Connection.LocalPort))
+    {
+      // Handle /health route
+      if (context.Request.Path == "/health")
+      {
+        context.Response.StatusCode = 200;
+        await context.Response.WriteAsync("OK");
+        return;
+      }
+
+      // We're going to handle this
+      // We will prevent the endpoint router from ever seeing this request
+      await _dispatcher.AddRequest(context.Request, context.Response);
+    }
+    else
+    {
+      await _next(context);
+    }
+  }
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
@@ -1,6 +1,7 @@
 namespace PwrDrvr.LambdaDispatch.Router;
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
 using PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
@@ -9,6 +10,10 @@ public struct LambdaInstanceCapacityMessage
 {
   public int PendingRequests { get; set; }
   public int RunningRequests { get; set; }
+
+  public double RequestsPerSecondEWMA { get; set; }
+
+  public double RequestDurationEWMA { get; set; }
 }
 
 public interface ILambdaInstanceManager
@@ -19,39 +24,55 @@ public interface ILambdaInstanceManager
 
   bool ValidateLambdaId(string lambdaId, [NotNullWhen(true)] out ILambdaInstance? instance);
 
-  Task ReenqueueUnusedConnection(LambdaConnection connection, string lambdaId);
+  void ReenqueueUnusedConnection(LambdaConnection connection, string lambdaId);
 
-  Task<LambdaConnection?> AddConnectionForLambda(HttpRequest request, HttpResponse response, string lambdaId, string channelId, bool immediateDispatch = false);
+  Task<LambdaConnection?> AddConnectionForLambda(HttpRequest request, HttpResponse response, string lambdaId, string channelId, AddConnectionDispatchMode dispatchMode = AddConnectionDispatchMode.Enqueue);
 
 #if TEST_RUNNERS
   void DebugAddInstance(string instanceId);
 #endif
 
-  Task UpdateDesiredCapacity(int pendingRequests, int runningRequests);
+  void UpdateDesiredCapacity(int pendingRequests, int runningRequests, double requestsPerSecondEWMA, double requestDurationEWMA);
 
-  void CloseInstance(ILambdaInstance instance);
-
-  void CloseInstance(string instanceId);
+  Task CloseInstance(ILambdaInstance instance, bool lambdaInitiated = false);
 }
 
 public class LambdaInstanceManager : ILambdaInstanceManager
 {
   private readonly ILogger<LambdaInstanceManager> _logger = LoggerInstance.CreateLogger<LambdaInstanceManager>();
 
+  private readonly CapacityManager _capacityManager;
+
   private readonly LeastOutstandingQueue _leastOutstandingQueue;
 
   private IBackgroundDispatcher? _dispatcher;
 
-  private volatile int _runningInstanceCount = 0;
-
-  private volatile int _desiredInstanceCount = 0;
-
-  private volatile int _startingInstanceCount = 0;
+  /// <summary>
+  /// Lock around instance counts
+  /// </summary>
+  private readonly object _instanceCountLock = new();
 
   /// <summary>
-  /// Count of instances that have called Close() but are still running
+  /// Number of instances that are desired
   /// </summary>
-  private volatile int _stoppingInstanceCount = 0;
+  private int _desiredInstanceCount = 0;
+
+  /// <summary>
+  /// Count of instances that running (connected, not starting, not stopping)
+  /// </summary>
+  private int _runningInstanceCount = 0;
+
+  /// <summary>
+  /// Count of instances that are starting
+  /// </summary>
+  private int _startingInstanceCount = 0;
+
+  /// <summary>
+  /// Count of instances that have called Close() but are still invoked
+  /// We subtract this off the running+starting count to determine if we can
+  /// allow an overlapping invoke while the still-running lambda is closing
+  /// </summary>
+  private int _stoppingInstanceCount = 0;
 
   private readonly int _maxConcurrentCount;
 
@@ -64,6 +85,13 @@ public class LambdaInstanceManager : ILambdaInstanceManager
   private readonly string? _functionNameQualifier;
 
   private readonly IMetricsLogger _metricsLogger;
+
+  private readonly Channel<LambdaInstanceCapacityMessage> _capacityChannel
+    = Channel.CreateBounded<LambdaInstanceCapacityMessage>(new BoundedChannelOptions(100)
+    {
+      FullMode = BoundedChannelFullMode.DropOldest,
+      SingleReader = true,
+    });
 
   /// <summary>
   /// Used to lookup instances by ID
@@ -80,9 +108,10 @@ public class LambdaInstanceManager : ILambdaInstanceManager
     _functionName = config.FunctionNameOnly;
     _functionNameQualifier = config.FunctionNameQualifier;
     _metricsLogger = metricsLogger;
+    _capacityManager = new(_maxConcurrentCount, _instanceCountMultiplier);
 
     // Start the capacity manager
-    Task.Run(ManageCapacity);
+    Task.Factory.StartNew(ManageCapacity, TaskCreationOptions.LongRunning);
   }
 
   public void AddBackgroundDispatcherReference(IBackgroundDispatcher dispatcher)
@@ -104,35 +133,36 @@ public class LambdaInstanceManager : ILambdaInstanceManager
     return _instances.TryGetValue(lambdaId, out instance);
   }
 
-  public async Task ReenqueueUnusedConnection(LambdaConnection connection, string lambdaId)
+  public void ReenqueueUnusedConnection(LambdaConnection connection, string lambdaId)
   {
     // Get the instance for the lambda
     if (_instances.TryGetValue(lambdaId, out var instance))
     {
       // Add the connection to the instance
       // The instance will eventually get rebalanced in the least outstanding queue
-      await instance.ReenqueueUnusedConnection(connection);
+      instance.ReenqueueUnusedConnection(connection);
 
       // Put this instance back into rotation if it was busy
       _leastOutstandingQueue.ReinstateFullInstance(instance);
     }
     else
     {
-      _logger.LogWarning("ReenqueueUnusedConnection - Connection added to Lambda Instance {lambdaId} that does not exist - closing with 409", lambdaId);
+      _logger.LogWarning("ReenqueueUnusedConnection - Connection added to Lambda that does not exist - closing with 409, LambdaId: {LambdaId}, ChannelId: {ChannelId}", lambdaId, connection.ChannelId);
+      _ = connection.Discard();
     }
   }
 
-  public async Task<LambdaConnection?> AddConnectionForLambda(HttpRequest request, HttpResponse response, string lambdaId, string channelId, bool immediateDispatch = false)
+  public async Task<LambdaConnection?> AddConnectionForLambda(HttpRequest request, HttpResponse response, string lambdaId, string channelId, AddConnectionDispatchMode dispatchMode = AddConnectionDispatchMode.Enqueue)
   {
     // Get the instance for the lambda
     if (_instances.TryGetValue(lambdaId, out var instance))
     {
       // Add the connection to the instance
       // The instance will eventually get rebalanced in the least outstanding queue
-      var connection = await instance.AddConnection(request, response, channelId, immediateDispatch).ConfigureAwait(false);
+      var connection = await instance.AddConnection(request, response, channelId, dispatchMode).ConfigureAwait(false);
 
       // Check where this instance is in the least outstanding queue
-      if (!immediateDispatch)
+      if (dispatchMode == AddConnectionDispatchMode.Enqueue)
       {
         _leastOutstandingQueue.ReinstateFullInstance(instance);
       }
@@ -159,41 +189,20 @@ public class LambdaInstanceManager : ILambdaInstanceManager
     return null;
   }
 
-
-  private Channel<LambdaInstanceCapacityMessage> _capacityChannel = Channel.CreateBounded<LambdaInstanceCapacityMessage>(new BoundedChannelOptions(1)
-  {
-    FullMode = BoundedChannelFullMode.DropOldest
-  });
-
-  private int ComputeDesiredInstanceCount(int pendingRequests, int runningRequests)
-  {
-    // Calculate the desired count
-    var cleanPendingRequests = Math.Max(pendingRequests, 0);
-    var cleanRunningRequests = Math.Max(runningRequests, 0);
-
-    // Calculate the desired count
-    var totalDesiredRequestCapacity = cleanPendingRequests + cleanRunningRequests;
-    var desiredInstanceCount = (int)Math.Ceiling((double)totalDesiredRequestCapacity / _maxConcurrentCount) * _instanceCountMultiplier;
-
-    // Special case for 0 pending or running requests
-    if (cleanPendingRequests == 0 && cleanRunningRequests == 0)
-    {
-      desiredInstanceCount = 0;
-    }
-
-    return desiredInstanceCount;
-  }
-
-  // TODO: This should project excess capacity and not use 100% of max capacity at all times
-  // TODO: This should not start new instances for pending requests at a 1/1 ratio but rather something less than that
   private async Task ManageCapacity()
   {
     Dictionary<string, ILambdaInstance> stoppingInstances = [];
+    var scaleTokenBucket = new TokenBucket(10, TimeSpan.FromMilliseconds(100));
+    var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+    int? deferredScaleInNewDesiredInstanceCount = null;
+    const int maxScaleOut = 5;
+    const double maxScaleOutPercent = .33;
+    const double maxScaleInPercent = .33;
+    Stopwatch swLastNonZeroTime = new();
 
     while (true)
     {
       // Setup a timer to run every 5 seconds or when we are asked to increase capacity
-      var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
       try
       {
         // Cleanup any stopping instances
@@ -211,77 +220,245 @@ public class LambdaInstanceManager : ILambdaInstanceManager
         var message = await _capacityChannel.Reader.ReadAsync(cts.Token);
         var pendingRequests = message.PendingRequests;
         var runningRequests = message.RunningRequests;
+        var requestsPerSecondEWMA = message.RequestsPerSecondEWMA;
+        var requestDurationEWMA = message.RequestDurationEWMA;
 
-        _logger.LogDebug("ManageCapacity - BEFORE - pendingRequests {pendingRequests}, runningRequests {runningRequests}, _desiredInstanceCount {_desiredInstanceCount}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount}", pendingRequests, runningRequests, _desiredInstanceCount, _runningInstanceCount, _startingInstanceCount);
-
-        var desiredInstanceCount = ComputeDesiredInstanceCount(pendingRequests, runningRequests);
-
-        _logger.LogDebug("ManageCapacity - COMPUTED - pendingRequests {pendingRequests}, runningRequests {runningRequests}, desiredCount {desiredCount}, _desiredInstanceCount {_desiredInstanceCount}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount}", pendingRequests, runningRequests, desiredInstanceCount, _desiredInstanceCount, _runningInstanceCount, _startingInstanceCount);
-
-        // Try to set the new desired count
-        // Because we own setting this value we can do a simple compare and swap
-        Interlocked.Exchange(ref _desiredInstanceCount, desiredInstanceCount);
-
-        // Start instances if needed
-        _metricsLogger.PutMetric("LambdaDesiredCount", desiredInstanceCount, Unit.Count);
-        var scaleOutCount = Math.Max(desiredInstanceCount - _runningInstanceCount - _startingInstanceCount, 0);
-        if (scaleOutCount > 0)
+        // Rip through any other messages, up to a limit of 100
+        // But keep reading if we keep ending on a message with no pending or running requests
+        var messagesToRead = 100;
+        var gotNonZeroPendingOrRunning = pendingRequests != 0 || runningRequests != 0;
+        while (_capacityChannel.Reader.TryRead(out var nextMessage)
+          && (--messagesToRead > 0 || nextMessage.PendingRequests == 0 && nextMessage.RunningRequests == 0))
         {
-          _metricsLogger.PutMetric("LambdaScaleOutCount", scaleOutCount, Unit.Count);
-        }
-        while (scaleOutCount-- > 0)
-        {
-          _logger.LogDebug("ManageCapacity - STARTING - pendingRequests {pendingRequests}, runningRequests {runningRequests}, _desiredInstanceCount {_desiredInstanceCount}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount}", pendingRequests, runningRequests, _desiredInstanceCount, _runningInstanceCount, _startingInstanceCount);
-          // Start a new instance
-          StartNewInstance();
+          pendingRequests = nextMessage.PendingRequests;
+          runningRequests = nextMessage.RunningRequests;
+          requestsPerSecondEWMA = nextMessage.RequestsPerSecondEWMA;
+          requestDurationEWMA = nextMessage.RequestDurationEWMA;
+
+          if (pendingRequests != 0 || runningRequests != 0)
+          {
+            gotNonZeroPendingOrRunning = true;
+          }
         }
 
-        MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceDesiredCount, _desiredInstanceCount);
+        // Start with the simple count
+        var simpleScalerDesiredInstanceCount = _capacityManager.SimpleDesiredInstanceCount(pendingRequests, runningRequests);
+        var newDesiredInstanceCount = simpleScalerDesiredInstanceCount;
 
-        _logger.LogDebug("ManageCapacity - AFTER - pendingRequests {pendingRequests}, runningRequests {runningRequests}, _desiredInstanceCount {_desiredInstanceCount}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount}", pendingRequests, runningRequests, _desiredInstanceCount, _runningInstanceCount, _startingInstanceCount);
+        if (gotNonZeroPendingOrRunning)
+        {
+          swLastNonZeroTime.Restart();
+        }
+
+        // Override the simple scale-from zero logic (which uses running and pending requests only)
+        // with the EWMA data, if available
+        // If we got a
+        int? ewmaScalerDesiredInstanceCount = null;
+        if (requestsPerSecondEWMA > 0 && requestDurationEWMA > 0)
+        {
+          ewmaScalerDesiredInstanceCount = _capacityManager.EwmaDesiredInstanceCount(requestsPerSecondEWMA, requestDurationEWMA);
+        }
+
+        // Switch to the EWMA scaler we've got activity
+        var shouldUseSimpleScaler = simpleScalerDesiredInstanceCount == 0
+            && !gotNonZeroPendingOrRunning
+            && messagesToRead != 0
+            && swLastNonZeroTime.ElapsedMilliseconds > 100;
+        if (!shouldUseSimpleScaler && ewmaScalerDesiredInstanceCount.HasValue)
+        {
+          newDesiredInstanceCount = ewmaScalerDesiredInstanceCount.Value;
+        }
+
+        //
+        // Locking instance counts - Do not do anything Async / IO in this block
+        //
+        lock (_instanceCountLock)
+        {
+          newDesiredInstanceCount = _capacityManager.ConstrainDesiredInstanceCount(
+            newDesiredInstanceCount, _desiredInstanceCount, maxScaleOut, maxScaleOutPercent, maxScaleInPercent);
+
+          // If we are already at the desired count and we have no starting instances, then we are done
+          if (!deferredScaleInNewDesiredInstanceCount.HasValue
+              && newDesiredInstanceCount == _desiredInstanceCount
+              && _startingInstanceCount + _runningInstanceCount - _stoppingInstanceCount <= _desiredInstanceCount)
+          {
+            // Clear any deferred scale in
+            deferredScaleInNewDesiredInstanceCount = null;
+
+            // Restore any missing instances
+            if (_startingInstanceCount + _runningInstanceCount - _stoppingInstanceCount < _desiredInstanceCount)
+            {
+              _logger.LogInformation("ManageCapacity - Desired count unchanged, restoring {} missing instances: _startingInstanceCount {} + _runningInstanceCount {} - _stoppingInstanceCount {} -> _desiredInstanceCount {}",
+                     _desiredInstanceCount - (_startingInstanceCount + _runningInstanceCount - _stoppingInstanceCount), _startingInstanceCount, _runningInstanceCount, _stoppingInstanceCount, _desiredInstanceCount); ;
+
+              while (_startingInstanceCount + _runningInstanceCount - _stoppingInstanceCount < _desiredInstanceCount)
+              {
+                // Start a new instance
+                StartNewInstance();
+              }
+            }
+
+            // Nothing to do
+            continue;
+          }
+
+          if (deferredScaleInNewDesiredInstanceCount.HasValue
+            && deferredScaleInNewDesiredInstanceCount.Value == newDesiredInstanceCount)
+          {
+            // We are already scheduled to scale to this count
+            continue;
+          }
+
+          // The current scale is already correct
+          if (newDesiredInstanceCount == _desiredInstanceCount)
+          {
+            // The new desired count is the same as the current count
+            // We have no need to scale in if we were going to
+            // We also have no need to scale up
+            deferredScaleInNewDesiredInstanceCount = null;
+            continue;
+          }
+
+          // See if we are allowed to adjust the desired count
+          // We are always allowed to scale out from 0 without consuming a token
+          // We are always allowed to scale in to 0 without consuming a token
+          var allowScaleWithoutToken = _desiredInstanceCount == 0 && newDesiredInstanceCount > 0;
+          if (allowScaleWithoutToken
+              // Allowing unlimited ins gets way too chatty
+              // || (_desiredInstanceCount > 0 && newDesiredInstanceCount == 0)
+              || scaleTokenBucket.TryGetToken())
+          {
+            var prevDesiredInstanceCount = _desiredInstanceCount;
+
+            _metricsLogger.PutMetric("PendingRequestCount", pendingRequests, Unit.Count);
+            _metricsLogger.PutMetric("RunningRequestCount", runningRequests, Unit.Count);
+
+            // Start instances if needed
+            if (newDesiredInstanceCount > _desiredInstanceCount)
+            {
+              _logger.LogInformation("ManageCapacity - Performing scale out: _desiredInstanceCount {_desiredInstanceCount} -> {newDesiredInstanceCount}, ewmaScalerDesiredInstanceCount {ewmaScalerDesiredInstanceCount}, simpleScalerDesiredInstanceCount {simpleScalerDesiredInstanceCount}, prevDesiredInstanceCount {prevDesiredInstanceCount}, requestsPerSecondEWMA {requestsPerSecondEWMA}, requestDurationEWMA {requestDurationEWMA}",
+                _desiredInstanceCount, newDesiredInstanceCount, ewmaScalerDesiredInstanceCount != null ? ewmaScalerDesiredInstanceCount.Value : null, simpleScalerDesiredInstanceCount, prevDesiredInstanceCount, Math.Round(requestsPerSecondEWMA, 1), Math.Round(requestDurationEWMA, 1));
+
+              // Clear any deferred scale in
+              deferredScaleInNewDesiredInstanceCount = null;
+
+              // Try to set the new desired count
+              // Because we own setting this value we can do a simple compare and swap
+              _desiredInstanceCount = newDesiredInstanceCount;
+
+              // Record the new desired count
+              MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceDesiredCount, _desiredInstanceCount);
+              _metricsLogger.PutMetric("LambdaDesiredCount", newDesiredInstanceCount, Unit.Count);
+
+              // Apply the scale out on the delta from reality to desired not on desired to desired
+              var scaleOutCount = Math.Max(newDesiredInstanceCount - (_runningInstanceCount + _startingInstanceCount - _stoppingInstanceCount), 0);
+              if (scaleOutCount > 0)
+              {
+                _metricsLogger.PutMetric("LambdaScaleOutCount", scaleOutCount, Unit.Count);
+              }
+              while (scaleOutCount-- > 0)
+              {
+                // Start a new instance
+                StartNewInstance();
+              }
+            }
+            else if (!deferredScaleInNewDesiredInstanceCount.HasValue)
+            {
+              _logger.LogInformation("ManageCapacity - Scheduling scale in: _desiredInstanceCount {_desiredInstanceCount} -> {newDesiredInstanceCount}, ewmaScalerDesiredInstanceCount {ewmaScalerDesiredInstanceCount}, simpleScalerDesiredInstanceCount {simpleScalerDesiredInstanceCount}, prevDesiredInstanceCount {prevDesiredInstanceCount}, requestsPerSecondEWMA {requestsPerSecondEWMA}, requestDurationEWMA {requestDurationEWMA}, _runningInstanceCount {}, _startingInstanceCount {}, _stoppingInstanceCount {}",
+                _desiredInstanceCount, newDesiredInstanceCount, ewmaScalerDesiredInstanceCount != null ? ewmaScalerDesiredInstanceCount.Value : null, simpleScalerDesiredInstanceCount, prevDesiredInstanceCount, Math.Round(requestsPerSecondEWMA, 1), Math.Round(requestDurationEWMA, 1), _runningInstanceCount, _startingInstanceCount, _stoppingInstanceCount);
+
+              // Schedule a scale in
+              deferredScaleInNewDesiredInstanceCount = newDesiredInstanceCount;
+              // This needs to be long enough for us to get a message from the background dispatcher
+              cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+            }
+            else
+            {
+              _logger.LogInformation("ManageCapacity - Adjusting scheduled scale in: _desiredInstanceCount {_desiredInstanceCount} -> {newDesiredInstanceCount}, ewmaScalerDesiredInstanceCount {ewmaScalerDesiredInstanceCount}, simpleScalerDesiredInstanceCount {simpleScalerDesiredInstanceCount}, prevDesiredInstanceCount {prevDesiredInstanceCount}, requestsPerSecondEWMA {requestsPerSecondEWMA}, requestDurationEWMA {requestDurationEWMA}",
+                _desiredInstanceCount, newDesiredInstanceCount, ewmaScalerDesiredInstanceCount != null ? ewmaScalerDesiredInstanceCount.Value : null, simpleScalerDesiredInstanceCount, prevDesiredInstanceCount, Math.Round(requestsPerSecondEWMA, 1), Math.Round(requestDurationEWMA, 1));
+
+              // Leave the schedule but adjust the amount
+              deferredScaleInNewDesiredInstanceCount = newDesiredInstanceCount;
+            }
+          }
+        }
       }
       catch (OperationCanceledException)
       {
-        // This was a timeout
-        // Time to check if we can reduce capacity
+        // This was a timeout - Reset the timeout
+        cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        _logger.LogDebug("ManageCapacity - Scale down check running");
 
-        // Stop only running instances if we have too many
-        // We do not count starting instances because they are not yet running
-        // Example:
-        // Running: 100
-        // Desired: 50
-        // Stopping: 20
-        // We need to stop 100 - 50 = 50 instances, but 20 are already stopping so 50 - 20 = 30 more need to be stopped
-        // Note: it doesn't matter if the instances in the dictionary are stopped or not.
-        // Example a few moments later when all 20 have stopped but we haven't updated our calcuation:
-        // Running: 80
-        // Desired: 50
-        // Stopping: 0
-        // We need to stop 80 - 50 = 30 instances, but 0 are already stopping so 30 - 0 = 30 more need to be stopped
-        // At worst, we won't stop enough until the next loop.
-        var scaleInCount = Math.Max(_runningInstanceCount - _desiredInstanceCount - stoppingInstances.Count, 0);
-        _metricsLogger.PutMetric("LambdaScaleInCount", scaleInCount, Unit.Count);
-        while (scaleInCount-- > 0)
+        //
+        // Locking instance counts - Do not do anything Async / IO in this block
+        //
+        lock (_instanceCountLock)
         {
-          // Get the least outstanding instance
-          if (_leastOutstandingQueue.TryRemoveLeastOutstandingInstance(out var leastBusyInstance))
+          // See if we have a deferred scale in to apply
+          if (deferredScaleInNewDesiredInstanceCount.HasValue)
           {
-            // Remove it from the collection
-            _instances.TryRemove(leastBusyInstance.Id, out var _);
+            if (deferredScaleInNewDesiredInstanceCount.Value == _desiredInstanceCount)
+            {
+              // Nothing to do, just go around
+              _logger.LogInformation("ManageCapacity - Skipping performing deferred scale in: _desiredInstanceCount {_desiredInstanceCount} -> {deferredScaleInNewDesiredInstanceCount.Value}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount}",
+                _desiredInstanceCount, deferredScaleInNewDesiredInstanceCount.Value, _runningInstanceCount, _startingInstanceCount);
+              deferredScaleInNewDesiredInstanceCount = null;
+              continue;
+            }
 
-            // Add to the stopping list
-            stoppingInstances.Add(leastBusyInstance.Id, leastBusyInstance);
+            _logger.LogInformation("ManageCapacity - Performing deferred scale in: _desiredInstanceCount {_desiredInstanceCount} -> {deferredScaleInNewDesiredInstanceCount.Value}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount}",
+              _desiredInstanceCount, deferredScaleInNewDesiredInstanceCount.Value, _runningInstanceCount, _startingInstanceCount);
+            _desiredInstanceCount = deferredScaleInNewDesiredInstanceCount.GetValueOrDefault();
+            _metricsLogger.PutMetric("LambdaDesiredCount", _desiredInstanceCount, Unit.Count);
+            MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceDesiredCount, _desiredInstanceCount);
 
-            // Close the instance
-            _logger.LogInformation("ManageCapacity - Closing least busy instance, LambdaId: {lambdaId}", leastBusyInstance.Id);
-            CloseInstance(leastBusyInstance);
+            // Clear the deferred value
+            deferredScaleInNewDesiredInstanceCount = null;
           }
-          else
+
+          // Time to check if we can reduce capacity
+
+          // Stop only running instances if we have too many
+          // We do not count starting instances because they are not yet running
+          // Example:
+          // Running: 100
+          // Desired: 50
+          // Stopping: 20
+          // We need to stop 100 - 50 = 50 instances, but 20 are already stopping so 50 - 20 = 30 more need to be stopped
+          // Note: it doesn't matter if the instances in the dictionary are stopped or not.
+          // Example a few moments later when all 20 have stopped but we haven't updated our calcuation:
+          // Running: 80
+          // Desired: 50
+          // Stopping: 0
+          // We need to stop 80 - 50 = 30 instances, but 0 are already stopping so 30 - 0 = 30 more need to be stopped
+          // At worst, we won't stop enough until the next loop.
+          var scaleInCount = Math.Max(_runningInstanceCount - _stoppingInstanceCount - _desiredInstanceCount, 0);
+          _metricsLogger.PutMetric("LambdaScaleInCount", scaleInCount, Unit.Count);
+          while (scaleInCount-- > 0)
           {
-            // We have no instances to close
-            // This can happen if all instances are busy and we're starting a lot of new instances to replace them
-            _logger.LogError("ManageCapacity - No instances to close - _desiredInstanceCount {_desiredInstanceCount}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount}", _desiredInstanceCount, _runningInstanceCount, _startingInstanceCount);
-            break;
+            // Get the least outstanding instance
+            if (_leastOutstandingQueue.TryRemoveLeastOutstandingInstance(out var leastBusyInstance))
+            {
+              // Remove it from the collection
+              _instances.TryRemove(leastBusyInstance.Id, out var _);
+
+              // Add to the stopping list
+              stoppingInstances.Add(leastBusyInstance.Id, leastBusyInstance);
+
+              // Close the instance
+              _logger.LogInformation("ManageCapacity - Closing least busy instance, LambdaId: {lambdaId}, OutstandingRequestCount: {}, AvailableConnectionsCount: {}, QueueApproximateCount: {}",
+                leastBusyInstance.Id, leastBusyInstance.OutstandingRequestCount, leastBusyInstance.AvailableConnectionCount, leastBusyInstance.QueueApproximateCount);
+              // We are not awaiting the close
+              _ = CloseInstance(leastBusyInstance);
+            }
+            else
+            {
+              // We have no instances to close
+              // This can happen if all instances are busy and we're starting a lot of new instances to replace them
+              _logger.LogError("ManageCapacity - No instances to close - _desiredInstanceCount {_desiredInstanceCount}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount}, _stoppingInstanceCount {_stoppingInstanceCount}",
+                _desiredInstanceCount, _runningInstanceCount, _startingInstanceCount, _stoppingInstanceCount);
+              break;
+            }
           }
         }
       }
@@ -292,21 +469,16 @@ public class LambdaInstanceManager : ILambdaInstanceManager
     }
   }
 
-  public async Task UpdateDesiredCapacity(int pendingRequests, int runningRequests)
+  public void UpdateDesiredCapacity(int pendingRequests, int runningRequests, double requestsPerSecondEWMA, double requestDurationEWMA)
   {
-    // In the nominal case of the right amount of capacity, we avoid writing to the channel
-    if (ComputeDesiredInstanceCount(pendingRequests, runningRequests) == _desiredInstanceCount)
-    {
-      // Nothing to do
-      return;
-    }
-
     // Send the message to the channel
     // This will return immediately because we drop any prior message and only keep the latest
-    await _capacityChannel.Writer.WriteAsync(new LambdaInstanceCapacityMessage()
+    _capacityChannel.Writer.TryWrite(new LambdaInstanceCapacityMessage()
     {
       PendingRequests = pendingRequests,
-      RunningRequests = runningRequests
+      RunningRequests = runningRequests,
+      RequestsPerSecondEWMA = requestsPerSecondEWMA,
+      RequestDurationEWMA = requestDurationEWMA,
     });
   }
 
@@ -329,8 +501,12 @@ public class LambdaInstanceManager : ILambdaInstanceManager
 
     // We need to keep track of how many Lambdas are running
     // We will replace this one if it's still desired
-    Interlocked.Increment(ref _runningInstanceCount);
-    MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceRunningCount, _runningInstanceCount);
+    lock (_instanceCountLock)
+    {
+      _runningInstanceCount++;
+      MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceRunningCount, _runningInstanceCount);
+      _metricsLogger.PutMetric("LambdaInstanceRunningCount", _runningInstanceCount, Unit.Count);
+    }
 
     // Add the instance to the least outstanding queue
     _leastOutstandingQueue.AddInstance(instance);
@@ -343,8 +519,13 @@ public class LambdaInstanceManager : ILambdaInstanceManager
   /// <returns></returns>
   private void StartNewInstance()
   {
-    Interlocked.Increment(ref _startingInstanceCount);
-    MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStartingCount, _startingInstanceCount);
+    lock (_instanceCountLock)
+    {
+      // We always increment the starting count
+      _startingInstanceCount++;
+      MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStartingCount, _startingInstanceCount);
+      _metricsLogger.PutMetric("LambdaInstanceStartingCount", _startingInstanceCount, Unit.Count);
+    }
 
     // Start a new LambdaInstance and add it to the list
     var instance = new LambdaInstance(_maxConcurrentCount, _functionName, _functionNameQualifier, channelCount: _channelCount, dispatcher: _dispatcher);
@@ -359,15 +540,20 @@ public class LambdaInstanceManager : ILambdaInstanceManager
     instance.OnOpen += (instance) =>
     {
       // We always decrement the starting count
-      Interlocked.Decrement(ref _startingInstanceCount);
-      MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStartingCount, _startingInstanceCount);
+      lock (_instanceCountLock)
+      {
+        _startingInstanceCount--;
+        MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStartingCount, _startingInstanceCount);
+        _metricsLogger.PutMetric("LambdaInstanceStartingCount", _startingInstanceCount, Unit.Count);
 
-      _logger.LogInformation("LambdaInstance {instanceId} opened", instance.Id);
+        _logger.LogInformation("LambdaInstance {instanceId} opened", instance.Id);
 
-      // We need to keep track of how many Lambdas are running
-      // We will replace this one if it's still desired
-      Interlocked.Increment(ref _runningInstanceCount);
-      MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceRunningCount, _runningInstanceCount);
+        // We need to keep track of how many Lambdas are running
+        // We will replace this one if it's still desired
+        _runningInstanceCount++;
+        MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceRunningCount, _runningInstanceCount);
+        _metricsLogger.PutMetric("LambdaInstanceRunningCount", _runningInstanceCount, Unit.Count);
+      }
 
       // Add the instance to the least outstanding queue
       _leastOutstandingQueue.AddInstance(instance);
@@ -380,77 +566,105 @@ public class LambdaInstanceManager : ILambdaInstanceManager
     instance.OnCloseInitiated += (instance) =>
     {
       // We always increment the stopping count when initiating a close
-      Interlocked.Increment(ref _stoppingInstanceCount);
-      MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStoppingCount, _stoppingInstanceCount);
-
-      _metricsLogger.PutMetric("LambdaInitiatedClose", 1, Unit.Count);
-
-      // Replace this instance if it's still desired
-      if (!instance.DoNotReplace)
+      lock (_instanceCountLock)
       {
-        if (_runningInstanceCount + _startingInstanceCount
-              < _desiredInstanceCount)
+        // Stopping instance count allows early replace
+        _stoppingInstanceCount++;
+        MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStoppingCount, _stoppingInstanceCount);
+        _metricsLogger.PutMetric("LambdaInstanceStoppingCount", _stoppingInstanceCount, Unit.Count);
+
+        if (instance.LamdbdaInitiatedClose)
         {
-          // We need to start a new instance
-          _metricsLogger.PutMetric("LambdaInitiatedCloseReplacing", 1, Unit.Count);
-          StartNewInstance();
+          _metricsLogger.PutMetric("LambdaInitiatedClose", 1, Unit.Count);
+        }
+
+        // Replace this instance if it's still desired
+        if (!instance.DoNotReplace)
+        {
+          if (_runningInstanceCount + _startingInstanceCount - _stoppingInstanceCount < _desiredInstanceCount)
+          {
+            // We need to start a new instance
+            if (instance.LamdbdaInitiatedClose)
+            {
+              // Mark that we are replacing this instance
+              // TODO: Only mark that we're replacing this if it was open for a while
+              instance.Replacing = true;
+              _metricsLogger.PutMetric("LambdaInitiatedCloseReplacing", 1, Unit.Count);
+            }
+            StartNewInstance();
+          }
         }
       }
     };
 
     instance.OnInvocationComplete += (instance) =>
       {
-        if (instance.WasOpened)
+        lock (_instanceCountLock)
         {
-          // The instance opened, so decrement the running count not the starting count
-          Interlocked.Decrement(ref _runningInstanceCount);
-          MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceRunningCount, _runningInstanceCount);
-        }
-        else
-        {
-          _logger.LogInformation("LambdaInstance {instanceId} was never opened, replacing", instance.Id);
-          // The instance never opened (e.g. throttled and failed) so decrement the starting count
-          Interlocked.Decrement(ref _startingInstanceCount);
-          MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStartingCount, _startingInstanceCount);
-        }
+          var transitionResult = instance.TransitionToDraining();
 
-        // If the instance just returned but was not marked as closing,
-        // then we should not decrement the stopping count.
-        // But if Closing was initiated then we should decrement the count.
-        if (!instance.TransitionToClosing())
-        {
-          Interlocked.Decrement(ref _stoppingInstanceCount);
-          MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStoppingCount, _stoppingInstanceCount);
-          _logger.LogInformation("LambdaInstance {instanceId} was closed already, _stoppingInstanceCount {_stoppingInstanceCount} (after decrement)", instance.Id, _stoppingInstanceCount);
-        }
+          // If the instance just returned but was not marked as closing,
+          // then we should not decrement the stopping count.
+          // But if Closing was initiated then we should decrement the count.
+          if (!transitionResult.TransitionedToDraining)
+          {
+            _stoppingInstanceCount--;
+            MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStoppingCount, _stoppingInstanceCount);
+            _metricsLogger.PutMetric("LambdaInstanceStoppingCount", _stoppingInstanceCount, Unit.Count);
 
-        _logger.LogInformation("LambdaInstance {instanceId} invocation complete, _desiredInstanceCount {_desiredInstanceCount}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount} (after decrement), _stoppingInstanceCount {_stoppingInstanceCount}",
-          instance.Id, _desiredInstanceCount, _runningInstanceCount, _startingInstanceCount, _stoppingInstanceCount);
+            _logger.LogInformation("LambdaInstance {instanceId} was closed already, _stoppingInstanceCount {_stoppingInstanceCount} (after decrement)", instance.Id, _stoppingInstanceCount);
+          }
 
-        // Remove this instance from the collection
-        _instances.TryRemove(instance.Id, out var instanceFromList);
+          if (transitionResult.OpenWasRejected)
+          {
+            _logger.LogInformation("LambdaInstance {instanceId} open was rejected, not replacing, not decrementing counts", instance.Id);
+            return;
+          }
 
-        // The instance will already be marked as closing
-        if (instanceFromList != null)
-        {
+          if (transitionResult.WasOpened)
+          {
+            // The instance opened, so decrement the running count not the starting count
+            _runningInstanceCount--;
+            MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceRunningCount, _runningInstanceCount);
+            _metricsLogger.PutMetric("LambdaInstanceRunningCount", _runningInstanceCount, Unit.Count);
+          }
+          else
+          {
+            _logger.LogInformation("LambdaInstance {instanceId} was never opened", instance.Id);
+            // The instance never opened (e.g. throttled and failed) so decrement the starting count
+            _startingInstanceCount--;
+            MetricsRegistry.Metrics.Measure.Gauge.SetValue(MetricsRegistry.LambdaInstanceStartingCount, _startingInstanceCount);
+            _metricsLogger.PutMetric("LambdaInstanceStartingCount", _startingInstanceCount, Unit.Count);
+          }
+
+          _logger.LogInformation("LambdaInstance {instanceId} invocation complete, _desiredInstanceCount {_desiredInstanceCount}, _runningInstanceCount {_runningInstanceCount}, _startingInstanceCount {_startingInstanceCount} (after decrement), _stoppingInstanceCount {_stoppingInstanceCount}",
+            instance.Id, _desiredInstanceCount, _runningInstanceCount, _startingInstanceCount, _stoppingInstanceCount);
+
+          // Remove this instance from the collection
+          _instances.TryRemove(instance.Id, out var instanceFromList);
+
           // We don't want to wait for this, let it happen in the background
-          instanceFromList.Close();
-        }
+          if (transitionResult.TransitionedToDraining)
+          {
+            // We were the first to notice the close - the close was not initiated by the router
+            // but by a faulted invoke
+            instance.InvokeCompleted();
+          }
 
-        if (instance.DoNotReplace)
-        {
-          _logger.LogInformation("LambdaInstance {instanceId} marked as DoNotReplace, not replacing", instance.Id);
-          return;
-        }
+          if (instance.DoNotReplace)
+          {
+            _logger.LogInformation("LambdaInstance {instanceId} marked as DoNotReplace, not replacing", instance.Id);
+            return;
+          }
 
-        // We need to keep track of how many Lambdas are running
-        // We will replace this one if it's still desired
-        if (_runningInstanceCount + _startingInstanceCount
-            < _desiredInstanceCount)
-        {
-          // We need to start a new instance
-          _metricsLogger.PutMetric("LambdaInvokeCompleteReplacing", 1, Unit.Count);
-          StartNewInstance();
+          // We need to keep track of how many Lambdas are running
+          // We will replace this one if it's still desired
+          if (_runningInstanceCount + _startingInstanceCount - _stoppingInstanceCount < _desiredInstanceCount)
+          {
+            // We need to start a new instance
+            _metricsLogger.PutMetric("LambdaInvokeCompleteReplacing", 1, Unit.Count);
+            StartNewInstance();
+          }
         }
       };
 
@@ -462,28 +676,13 @@ public class LambdaInstanceManager : ILambdaInstanceManager
   /// Gracefully close an instance
   /// </summary>
   /// <param name="instance"></param>
-  public void CloseInstance(ILambdaInstance instance)
+  public async Task CloseInstance(ILambdaInstance instance, bool lambdaInitiated = false)
   {
     // The instance is going to get cleaned up by the OnInvocationComplete handler
     // Counts will be decremented, the instance will be replaced, etc.
     // We just need to get the Lambda to return from the invoke
-    instance.Close();
-  }
-
-  /// <summary>
-  /// Gracefully close an instance
-  /// </summary>
-  /// <param name="instanceId"></param>
-  /// <returns></returns>
-  public void CloseInstance(string instanceId)
-  {
-    if (_instances.TryGetValue(instanceId, out var instance))
-    {
-      CloseInstance(instance);
-    }
-    else
-    {
-      _logger.LogInformation("Instance {instanceId} not found during close", instanceId);
-    }
+    // If the Lambda initiated the close we can still replace it
+    // (this can be for deadline exceeded or for lambda detecting idle)
+    await instance.Close(doNotReplace: !lambdaInitiated, lambdaInitiated: lambdaInitiated);
   }
 }

--- a/src/PwrDrvr.LambdaDispatch.Router/PendingRequest.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/PendingRequest.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics;
+
+namespace PwrDrvr.LambdaDispatch.Router;
+
+public class PendingRequest
+{
+  public HttpRequest Request { get; private set; }
+  public HttpResponse Response { get; private set; }
+  public TaskCompletionSource ResponseFinishedTCS { get; private set; } = new TaskCompletionSource();
+  public CancellationTokenSource GatewayTimeoutCTS { get; private set; } = new CancellationTokenSource();
+  public DateTime? DispatchTime { get; private set; }
+  public bool Dispatched { get; private set; } = false;
+
+  private readonly Stopwatch _swDispatch = Stopwatch.StartNew();
+  private readonly Stopwatch _swResponse = Stopwatch.StartNew();
+
+  public TimeSpan DispatchDelay
+  {
+    get
+    {
+      return _swDispatch.Elapsed;
+    }
+  }
+
+  public TimeSpan Duration
+  {
+    get
+    {
+      return _swResponse.Elapsed;
+    }
+  }
+
+  public PendingRequest(HttpRequest request, HttpResponse response)
+  {
+    Request = request;
+    Response = response;
+  }
+
+  public void Abort()
+  {
+    GatewayTimeoutCTS.Cancel();
+  }
+
+  public void RecordDispatchTime()
+  {
+    if (Dispatched)
+    {
+      return;
+    }
+    Dispatched = true;
+    _swDispatch.Stop();
+  }
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/Program.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Program.cs
@@ -75,6 +75,8 @@ public class Program
 
     public static void Main(string[] args)
     {
+        Console.WriteLine($"GIT_HASH: {Environment.GetEnvironmentVariable("GIT_HASH") ?? "none"}");
+        Console.WriteLine($"BUILD_TIME: {Environment.GetEnvironmentVariable("BUILD_TIME") ?? "none"}");
         AdjustThreadPool();
         CreateHostBuilder(args).Build().Run();
     }

--- a/src/PwrDrvr.LambdaDispatch.Router/ShutdownSignal.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/ShutdownSignal.cs
@@ -1,0 +1,11 @@
+namespace PwrDrvr.LambdaDispatch.Router;
+
+public interface IShutdownSignal
+{
+  public CancellationTokenSource Shutdown { get; }
+}
+
+public class ShutdownSignal : IShutdownSignal
+{
+  public CancellationTokenSource Shutdown { get; private set; } = new();
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/TokenBucket.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/TokenBucket.cs
@@ -1,0 +1,41 @@
+using System.Threading.Channels;
+
+namespace PwrDrvr.LambdaDispatch.Router;
+
+public class TokenBucket
+{
+  private readonly Channel<int> _channel;
+  private readonly Timer _timer;
+
+  public TokenBucket(int maxTokens, TimeSpan tokenAddInterval)
+  {
+    _channel = Channel.CreateBounded<int>(maxTokens);
+
+    // Fill the bucket up
+    for (var i = 0; i < maxTokens; i++)
+    {
+      _channel.Writer.TryWrite(0);
+    }
+
+    // Start the timer to add tokens at the specified rate
+    _timer = new Timer(_ => AddToken(), null, tokenAddInterval, tokenAddInterval);
+  }
+
+  private void AddToken()
+  {
+    // Try to write to the channel, but don't wait if it's full
+    _ = _channel.Writer.TryWrite(0);
+  }
+
+  public ValueTask<int> GetTokenAsync(CancellationToken cancellationToken = default)
+  {
+    // Try to read from the channel, waiting if necessary
+    return _channel.Reader.ReadAsync(cancellationToken);
+  }
+
+  public bool TryGetToken()
+  {
+    // Try to read from the channel, but don't wait if it's empty
+    return _channel.Reader.TryRead(out var _);
+  }
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/TrailingAverage.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/TrailingAverage.cs
@@ -1,0 +1,61 @@
+public class TrailingAverage
+{
+  private readonly List<(DateTime timestamp, double sum, int count)> _data = new List<(DateTime, double, int)>();
+  private double _totalSum = 0;
+  private int _totalCount = 0;
+
+  private void CleanupOldData()
+  {
+    var now = DateTime.UtcNow;
+    var currentSecond = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+
+    // Remove items that are older than 5 seconds from the end of the list
+    while (_data.Count > 0 && (currentSecond - _data[^1].timestamp).TotalSeconds > 5)
+    {
+      var oldest = _data[^1];
+      _totalSum -= oldest.sum;
+      _totalCount -= oldest.count;
+      _data.RemoveAt(_data.Count - 1);
+    }
+  }
+
+  public void Add(double value)
+  {
+    CleanupOldData();
+
+    var now = DateTime.UtcNow;
+    var currentSecond = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+
+    // If the list is empty or the current second is different from the first second in the list,
+    // insert a new item at the beginning of the list
+    if (_data.Count == 0 || _data[0].timestamp != currentSecond)
+    {
+      _data.Insert(0, (currentSecond, value, 1));
+    }
+    else
+    {
+      // Otherwise, update the sum and count for the current second
+      var first = _data[0];
+      _data[0] = (first.timestamp, first.sum + value, first.count + 1);
+    }
+
+    _totalSum += value;
+    _totalCount++;
+  }
+
+  public double Average
+  {
+    get
+    {
+      CleanupOldData();
+
+      // We are not interested in mathematical correctness... if there are no stats, return 0
+      if (_totalCount == 0)
+      {
+        return 0;
+      }
+
+      return _totalSum / _totalCount;
+    }
+  }
+}

--- a/src/PwrDrvr.LambdaDispatch.Router/WeightedAverage.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/WeightedAverage.cs
@@ -1,0 +1,75 @@
+namespace PwrDrvr.LambdaDispatch.Router;
+
+using System.Diagnostics;
+using App.Metrics.Concurrency;
+
+public class WeightedAverage
+{
+  private readonly StripedLongAdder _value = new();
+  private readonly StripedLongAdder _count = new();
+
+  private readonly int _windowSizeInSeconds;
+  private readonly double Alpha;
+  private readonly int tickIntervalMs = 100;
+  private double _ewma = 0;
+  private readonly bool _mean;
+
+  /// <summary>
+  /// Get the Exponential Weighted Moving Average that is computed in the background
+  /// </summary>
+  public double EWMA { get { return _ewma; } }
+
+  /// <summary>
+  /// Thread safe computation of EWMA of values or EWMA of mean of values
+  /// </summary>
+  /// <param name="windowSizeInSeconds"></param>
+  /// <param name="mean">Compute EWMA of mean of values</param>
+  public WeightedAverage(int windowSizeInSeconds, bool mean = false)
+  {
+    _mean = mean;
+    _windowSizeInSeconds = windowSizeInSeconds;
+
+    Alpha = 1 - Math.Exp(-tickIntervalMs / (_windowSizeInSeconds * 1000.0));
+
+    // Start a task to compute the average
+    Task.Run(async () =>
+    {
+      while (true)
+      {
+        try
+        {
+          await Task.Delay((int)tickIntervalMs);
+
+          var currentValue = _value.GetAndReset();
+          var currentCount = _count.GetAndReset();
+
+          var instantRate = (double)currentValue / (tickIntervalMs / 1000.0);
+          var instantMean = currentCount > 0 ? (double)currentValue / (double)currentCount : 0;
+
+          // Calculate the EWMA of the counts per second
+          if (_mean)
+          {
+            _ewma = Alpha * instantMean + (1 - Alpha) * _ewma;
+          }
+          else
+          {
+            _ewma = Alpha * instantRate + (1 - Alpha) * _ewma;
+          }
+        }
+        catch (Exception ex)
+        {
+          Console.WriteLine($"Exception in WeightedAverage: {ex.Message}");
+        }
+      }
+    });
+  }
+
+  public void Add(long count = 1)
+  {
+    _value.Add(count);
+    if (_mean)
+    {
+      _count.Add(1);
+    }
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/CapacityManagerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/CapacityManagerTests.cs
@@ -1,0 +1,69 @@
+namespace PwrDrvr.LambdaDispatch.Router.Tests;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class CapacityManagerTests
+{
+  [TestCase(0, 0, 0, 0, ExpectedResult = 0)]
+  [TestCase(10, 2, 0, 0, ExpectedResult = 0)]
+  [TestCase(10, 2, 1, 1, ExpectedResult = 1)]
+  [TestCase(1, 1, 1, 1, ExpectedResult = 2)]
+  [TestCase(10, 5, 2, 2, ExpectedResult = 2)]
+  [TestCase(20, 10, 5, 2, ExpectedResult = 2)]
+  [TestCase(10, 2, 100, 2, ExpectedResult = 6)]
+  // 47 would give 235 target connections but 940 total connections
+  [TestCase(20, 4, 1000, 110, ExpectedResult = 47)]
+  public int SimpleDesiredInstanceCount_ReturnsExpectedResult(
+    int maxConcurrentCount, int instanceCountMultiplier, int pendingRequests, int runningRequests)
+  {
+    var capacityManager = new CapacityManager(maxConcurrentCount, instanceCountMultiplier);
+    return capacityManager.SimpleDesiredInstanceCount(pendingRequests, runningRequests);
+  }
+
+  [TestCase(0, 0, 0, 0, ExpectedResult = 0)]
+  [TestCase(10, 2, 0, 0, ExpectedResult = 0)]
+  [TestCase(10, 2, 1, 0, ExpectedResult = 1)]
+  [TestCase(10, 2, 1, 1, ExpectedResult = 1)]
+  [TestCase(10, 2, 1, 1500, ExpectedResult = 1)]
+  [TestCase(10, 2, 1, 59500, ExpectedResult = 12)]
+  [TestCase(10, 2, 3000, 21, ExpectedResult = 13)]
+  [TestCase(10, 2, 3000, 6, ExpectedResult = 4)]
+  [TestCase(1, 1, 1, 1, ExpectedResult = 1)]
+  [TestCase(10, 5, 2, 2, ExpectedResult = 1)]
+  [TestCase(20, 10, 5, 2, ExpectedResult = 1)]
+  [TestCase(10, 2, 100, 2, ExpectedResult = 1)]
+  [TestCase(20, 4, 1000, 100, ExpectedResult = 20)]
+  public int EwmaDesiredInstanceCount_ReturnsExpectedResult(
+   int maxConcurrentCount, int instanceCountMultiplier, double requestsPerSecondEWMA, double requestDurationEWMA)
+  {
+    var capacityManager = new CapacityManager(maxConcurrentCount, instanceCountMultiplier);
+    return capacityManager.EwmaDesiredInstanceCount(requestsPerSecondEWMA, requestDurationEWMA);
+  }
+
+  // Scale Out Tests
+  [TestCase(0, 0, 0, 0.33, 0.33, ExpectedResult = 0)]
+  [TestCase(10, 2, 0, 0.33, 0.33, ExpectedResult = 3)]
+  [TestCase(25, 15, 5, 0.5, 0.33, ExpectedResult = 23)]
+  [TestCase(10, 2, 5, 0.33, 0.33, ExpectedResult = 7)]
+  [TestCase(10, 2, 1, 0.33, 0.33, ExpectedResult = 3)]
+  [TestCase(1, 1, 1, 0.33, 0.33, ExpectedResult = 1)]
+  [TestCase(13, 3, 2, 1, 0.33, ExpectedResult = 6)]
+  [TestCase(13, 3, 5, 1, 0.33, ExpectedResult = 8)]
+  [TestCase(20, 10, 5, 0.33, 0.33, ExpectedResult = 15)]
+  [TestCase(10, 2, 100, 0.33, 0.33, ExpectedResult = 10)]
+  // Scale In Tests
+  [TestCase(2, 10, 0, 0.33, 0.33, ExpectedResult = 6)]
+  [TestCase(0, 1, 5, 0.33, 0.33, ExpectedResult = 0)]
+  [TestCase(13, 30, 5, 0.33, 0.33, ExpectedResult = 20)]
+  [TestCase(0, 400, 5, 0.33, 0.33, ExpectedResult = 0)]
+  [TestCase(0, 4, 5, 0.1, 0.1, ExpectedResult = 0)]
+  public int ConstrainDesiredInstanceCount_ReturnsExpectedResult(
+    int proposedDesiredInstanceCount, int currentDesiredInstanceCount,
+      int maxScaleOut, double maxScaleOutRatio, double maxScaleInRatio)
+  {
+    var capacityManager = new CapacityManager(10, 2);
+    return capacityManager.ConstrainDesiredInstanceCount(proposedDesiredInstanceCount, currentDesiredInstanceCount,
+      maxScaleOut, maxScaleOutRatio, maxScaleInRatio);
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
@@ -44,37 +44,37 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
 
-      Assert.That(instance.AddConnection(request.Object, response.Object, "channel-1", false), Is.Not.Null);
+      Assert.That(instance.AddConnection(request.Object, response.Object, "channel-1", AddConnectionDispatchMode.Enqueue), Is.Not.Null);
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(1));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(1));
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
 
-      await instance.AddConnection(request.Object, response.Object, "channel-2", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-2", AddConnectionDispatchMode.Enqueue);
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(2));
-      await instance.AddConnection(request.Object, response.Object, "channel-3", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-3", AddConnectionDispatchMode.Enqueue);
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(3));
-      await instance.AddConnection(request.Object, response.Object, "channel-4", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-4", AddConnectionDispatchMode.Enqueue);
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(4));
-      await instance.AddConnection(request.Object, response.Object, "channel-5", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-5", AddConnectionDispatchMode.Enqueue);
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(5));
-      await instance.AddConnection(request.Object, response.Object, "channel-6", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-6", AddConnectionDispatchMode.Enqueue);
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(6));
-      await instance.AddConnection(request.Object, response.Object, "channel-7", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-7", AddConnectionDispatchMode.Enqueue);
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(7));
-      await instance.AddConnection(request.Object, response.Object, "channel-8", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-8", AddConnectionDispatchMode.Enqueue);
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(8));
-      await instance.AddConnection(request.Object, response.Object, "channel-9", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-9", AddConnectionDispatchMode.Enqueue);
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(9));
-      await instance.AddConnection(request.Object, response.Object, "channel-10", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-10", AddConnectionDispatchMode.Enqueue);
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(10));
@@ -83,7 +83,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       // Can have more connections than maxConcurrentCount?
       // This kinda makes sense
-      await instance.AddConnection(request.Object, response.Object, "channel-11", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-11", AddConnectionDispatchMode.Enqueue);
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(11));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(10));
@@ -114,7 +114,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       // These should be visible
       for (var i = 1; i <= maxConcurrentCount; i++)
       {
-        Assert.That(instance.AddConnection(request.Object, response.Object, $"channel-{i}", false), Is.Not.Null);
+        Assert.That(instance.AddConnection(request.Object, response.Object, $"channel-{i}", AddConnectionDispatchMode.Enqueue), Is.Not.Null);
         Assert.That(instance.QueueApproximateCount, Is.EqualTo(i));
         Assert.That(instance.AvailableConnectionCount, Is.EqualTo(i));
         Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
@@ -123,7 +123,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       // These should be hidden
       for (var i = 1; i <= maxConcurrentCount; i++)
       {
-        Assert.That(instance.AddConnection(request.Object, response.Object, $"channel-{i + 10}", false), Is.Not.Null);
+        Assert.That(instance.AddConnection(request.Object, response.Object, $"channel-{i + 10}", AddConnectionDispatchMode.Enqueue), Is.Not.Null);
         Assert.That(instance.QueueApproximateCount, Is.EqualTo(i + maxConcurrentCount));
         Assert.That(instance.AvailableConnectionCount, Is.EqualTo(maxConcurrentCount));
         Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
@@ -175,7 +175,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       // These should not be visible but should count as outstanding
       for (var i = 1; i <= maxConcurrentCount; i++)
       {
-        Assert.That(instance.AddConnection(request.Object, response.Object, $"channel-{i}", immediateDispatch: true), Is.Not.Null);
+        Assert.That(instance.AddConnection(request.Object, response.Object, $"channel-{i}", AddConnectionDispatchMode.ImmediateDispatch), Is.Not.Null);
         Assert.That(instance.QueueApproximateCount, Is.EqualTo(0));
         Assert.That(instance.AvailableConnectionCount, Is.EqualTo(0));
         Assert.That(instance.OutstandingRequestCount, Is.EqualTo(i));
@@ -200,15 +200,15 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       // Start the Lambda
       instance.Start();
 
-      await instance.AddConnection(request.Object, response.Object, "channel-1", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-1", AddConnectionDispatchMode.Enqueue);
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(1));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(1));
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));
 
-      await instance.AddConnection(request.Object, response.Object, "channel-2", false);
-      await instance.AddConnection(request.Object, response.Object, "channel-3", false);
-      await instance.AddConnection(request.Object, response.Object, "channel-4", false);
+      await instance.AddConnection(request.Object, response.Object, "channel-2", AddConnectionDispatchMode.Enqueue);
+      await instance.AddConnection(request.Object, response.Object, "channel-3", AddConnectionDispatchMode.Enqueue);
+      await instance.AddConnection(request.Object, response.Object, "channel-4", AddConnectionDispatchMode.Enqueue);
 
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(4));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(4));
@@ -222,7 +222,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(1));
 
       // Reinstate the connection
-      await instance.ReenqueueUnusedConnection(connection);
+      instance.ReenqueueUnusedConnection(connection);
       Assert.That(instance.QueueApproximateCount, Is.EqualTo(4));
       Assert.That(instance.AvailableConnectionCount, Is.EqualTo(4));
       Assert.That(instance.OutstandingRequestCount, Is.EqualTo(0));

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
@@ -67,7 +67,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
 
       var instance = new Mock<ILambdaInstance>();
-      var connection = new Mock<LambdaConnection>(request.Object, response.Object, instance.Object, "channel-1");
+      var connection = new Mock<LambdaConnection>(request.Object, response.Object, instance.Object, "channel-1", false);
 
       var id = "instance-1";
       instance.Setup(i => i.Id).Returns(id);
@@ -108,7 +108,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
 
       var instance = new Mock<ILambdaInstance>();
-      var connection = new Mock<LambdaConnection>(request.Object, response.Object, instance.Object, "channel-1");
+      var connection = new Mock<LambdaConnection>(request.Object, response.Object, instance.Object, "channel-1", false);
 
       var id = "instance-1";
       instance.Setup(i => i.Id).Returns(id);
@@ -147,7 +147,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
 
       var instance = new Mock<ILambdaInstance>();
-      var connection = new Mock<LambdaConnection>(request.Object, response.Object, instance.Object, "channel-1");
+      var connection = new Mock<LambdaConnection>(request.Object, response.Object, instance.Object, "channel-1", false);
 
       var id = "instance-1";
       instance.Setup(i => i.Id).Returns(id);
@@ -193,7 +193,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var response = new Mock<Microsoft.AspNetCore.Http.HttpResponse>();
 
       var instance = new Mock<ILambdaInstance>();
-      var connection = new Mock<LambdaConnection>(request.Object, response.Object, instance.Object, "channel-1");
+      var connection = new Mock<LambdaConnection>(request.Object, response.Object, instance.Object, "channel-1", false);
 
       var id = "instance-1";
       instance.Setup(i => i.Id).Returns(id);

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
@@ -51,8 +51,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       var result = queue.TryGetLeastOustandingConnection(out var connection);
 
-      Assert.IsFalse(result);
-      Assert.IsNull(connection);
+      Assert.That(result, Is.False);
+      Assert.That(connection, Is.Null);
     }
 
     [Test]
@@ -72,6 +72,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var id = "instance-1";
       instance.Setup(i => i.Id).Returns(id);
       instance.Setup(i => i.State).Returns(LambdaInstanceState.Open);
+      instance.Setup(i => i.IsOpen).Returns(true);
       instance.Setup(i => i.AvailableConnectionCount).Returns(1);
       var connectionObject = connection.Object;
       instance.Setup(i => i.TryGetConnection(out connectionObject, false)).Returns(true);
@@ -91,7 +92,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       instance.Setup(i => i.TryGetConnection(out connectionObject, false)).Throws<Exception>();
       result = queue.TryGetLeastOustandingConnection(out dequeuedConnection);
 
-      Assert.IsFalse(result);
+      Assert.That(result, Is.False);
       Assert.IsNull(dequeuedConnection);
     }
 
@@ -113,6 +114,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var id = "instance-1";
       instance.Setup(i => i.Id).Returns(id);
       instance.Setup(i => i.State).Returns(LambdaInstanceState.Open);
+      instance.Setup(i => i.IsOpen).Returns(true);
       instance.Setup(i => i.AvailableConnectionCount).Returns(1);
       instance.Setup(i => i.OutstandingRequestCount).Returns(0);
       var connectionObject = connection.Object;
@@ -123,16 +125,16 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       var result = queue.TryGetLeastOustandingConnection(out var dequeuedConnection);
 
-      Assert.IsTrue(result);
-      Assert.IsNotNull(dequeuedConnection);
+      Assert.That(result, Is.True);
+      Assert.That(dequeuedConnection, Is.Not.Null);
 
       // Getting another instance should fail
       instance.Setup(i => i.OutstandingRequestCount).Returns(1);
       instance.Setup(i => i.TryGetConnection(out connectionObject, false)).Returns(false);
       result = queue.TryGetLeastOustandingConnection(out dequeuedConnection);
 
-      Assert.IsFalse(result);
-      Assert.IsNull(dequeuedConnection);
+      Assert.That(result, Is.False);
+      Assert.That(dequeuedConnection, Is.Null);
     }
 
     [Test]
@@ -152,6 +154,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var id = "instance-1";
       instance.Setup(i => i.Id).Returns(id);
       instance.Setup(i => i.State).Returns(LambdaInstanceState.Open);
+      instance.Setup(i => i.IsOpen).Returns(true);
       instance.Setup(i => i.AvailableConnectionCount).Returns(0);
       instance.Setup(i => i.OutstandingRequestCount).Returns(1);
       var connectionObject = connection.Object;
@@ -198,6 +201,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var id = "instance-1";
       instance.Setup(i => i.Id).Returns(id);
       instance.Setup(i => i.State).Returns(LambdaInstanceState.Open);
+      instance.Setup(i => i.IsOpen).Returns(true);
       instance.SetupSequence(i => i.AvailableConnectionCount).Returns(1).Returns(1).Returns(0);
       instance.Setup(i => i.OutstandingRequestCount).Returns(1);
       var connectionObject = connection.Object;

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/TrailingAverageTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/TrailingAverageTests.cs
@@ -1,0 +1,38 @@
+namespace PwrDrvr.LambdaDispatch.Router.Tests;
+
+[TestFixture]
+public class TrailingAverageTests
+{
+  [Test]
+  public void Test_Add_And_Average()
+  {
+    var trailingAverage = new TrailingAverage();
+
+    trailingAverage.Add(1);
+    Assert.That(trailingAverage.Average, Is.EqualTo(1));
+
+    trailingAverage.Add(2);
+    Assert.That(trailingAverage.Average, Is.EqualTo(1.5));
+
+    trailingAverage.Add(3);
+    Assert.That(trailingAverage.Average, Is.EqualTo(2));
+  }
+
+  [Test]
+  public void Test_Average_With_Old_Data()
+  {
+    var trailingAverage = new TrailingAverage();
+
+    trailingAverage.Add(1);
+    trailingAverage.Add(2);
+    trailingAverage.Add(3);
+
+    // Wait for 6 seconds to make sure the old data is cleaned up
+    Thread.Sleep(6000);
+
+    Assert.That(trailingAverage.Average, Is.EqualTo(0));
+
+    trailingAverage.Add(4);
+    Assert.That(trailingAverage.Average, Is.EqualTo(4));
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/WeightedAverageTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/WeightedAverageTests.cs
@@ -1,0 +1,119 @@
+namespace PwrDrvr.LambdaDispatch.Router.Tests;
+
+using PwrDrvr.LambdaDispatch.Router;
+
+[TestFixture]
+public class WeightedAverageTests
+{
+  [Test]
+  public void TestAdd()
+  {
+    var weightedAverage = new WeightedAverage(60);
+    weightedAverage.Add(5);
+    Thread.Sleep(150);
+    Assert.That(weightedAverage.EWMA, Is.GreaterThan(0));
+  }
+
+  [Test]
+  public void TestEWMA()
+  {
+    var weightedAverage = new WeightedAverage(5);
+    weightedAverage.Add(50);
+    Thread.Sleep(120);
+    var ewma0 = weightedAverage.EWMA;
+    Assert.That(ewma0, Is.GreaterThan(0));
+
+    weightedAverage.Add(50);
+    Thread.Sleep(120);
+    var ewma1 = weightedAverage.EWMA;
+    Assert.That(ewma1, Is.GreaterThan(0));
+
+    weightedAverage.Add(200);
+    Thread.Sleep(120);
+    var ewma2 = weightedAverage.EWMA;
+
+    Assert.That(ewma2, Is.GreaterThan(ewma1));
+  }
+
+  // [Test]
+  // public void TestCleanupOldData()
+  // {
+  //   var weightedAverage = new WeightedAverage(2);
+  //   weightedAverage.Add(5);
+  //   Thread.Sleep(1100);
+  //   weightedAverage.Add(10);
+  //   Thread.Sleep(2100); // Wait for more than two seconds to ensure the old data is cleaned up
+  //   var ewma = weightedAverage.EWMA;
+
+  //   Assert.LessOrEqual(ewma, 10);
+  // }
+
+  [Test]
+  public void TestMeanTrue()
+  {
+    // Arrange
+    var weightedAverage = new WeightedAverage(5, true);
+
+    // Act
+    for (int i = 1; i <= 10; i++)
+    {
+      weightedAverage.Add(i);
+    }
+
+    Thread.Sleep(150); // Sleep to allow the background task to compute the EWMA
+
+    // Assert
+    // The exact value of EWMA will depend on the timing of the test, so we can't check for a specific value.
+    // Instead, we can check that it's within a reasonable range.
+    Assert.That(weightedAverage.EWMA, Is.GreaterThan(0));
+    Assert.That(weightedAverage.EWMA, Is.LessThan(10));
+  }
+
+  [Test]
+  public async Task TestConstantRateCalc()
+  {
+    // Arrange
+    var weightedAverage = new WeightedAverage(5);
+    var timer = new System.Timers.Timer(50);
+    var counter = 0;
+
+    timer.Elapsed += (sender, e) =>
+    {
+      for (int i = 0; i < 200; i++)
+      {
+        weightedAverage.Add(1);
+      }
+
+      counter++;
+
+      // Stop the timer after approximately 5 seconds
+      if (counter >= 100)
+      {
+        timer.Stop();
+      }
+    };
+
+    // Act
+    timer.Start();
+
+    double lastEWMA = 0;
+
+    // Wait for the timer to finish
+    while (timer.Enabled)
+    {
+      await Task.Delay(110);
+
+      double currentEWMA = weightedAverage.EWMA;
+
+      Assert.That(currentEWMA, Is.GreaterThanOrEqualTo(lastEWMA));
+
+      // The exact value of EWMA will depend on the timing of the test, so we can't check for a specific value.
+      // Instead, we can check that it's within a reasonable range.
+      Assert.That(weightedAverage.EWMA, Is.GreaterThan(0));
+      // Assert.That(weightedAverage.EWMA, Is.GreaterThan(1000));
+      Assert.That(weightedAverage.EWMA, Is.LessThanOrEqualTo(10000));
+
+      lastEWMA = currentEWMA;
+    }
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/WeightedAverageTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/WeightedAverageTests.cs
@@ -98,6 +98,10 @@ public class WeightedAverageTests
 
     double lastEWMA = 0;
 
+    await Task.Delay(110);
+
+    lastEWMA = weightedAverage.EWMA;
+
     // Wait for the timer to finish
     while (timer.Enabled)
     {
@@ -105,12 +109,11 @@ public class WeightedAverageTests
 
       double currentEWMA = weightedAverage.EWMA;
 
-      Assert.That(currentEWMA, Is.GreaterThanOrEqualTo(lastEWMA));
+      Assert.That(currentEWMA, Is.InRange(lastEWMA * .95, lastEWMA * 4));
 
       // The exact value of EWMA will depend on the timing of the test, so we can't check for a specific value.
       // Instead, we can check that it's within a reasonable range.
       Assert.That(weightedAverage.EWMA, Is.GreaterThan(0));
-      // Assert.That(weightedAverage.EWMA, Is.GreaterThan(1000));
       Assert.That(weightedAverage.EWMA, Is.LessThanOrEqualTo(10000));
 
       lastEWMA = currentEWMA;


### PR DESCRIPTION
## Overall

- Massive reduction in scale thrashing
- Big reduction in cost
- Big improvement in performance due to increased stability
- Able to hold up to `k6` arrival rate tests (ramping, constant)

## Router

- BoundedCollection for background dispatcher (eliminates the 1 second sleep)
- Add EWMA class and scale calculation
- Fix scale down when load is reduced but does not go to zero (used to stay scaled up)
- Fix counts going negative
- Allow MaxConcurrentRequests up to 100
- Fix Ctrl-C exit for router
- Consolidate duplicate background dispatch code
- Add GIT_HASH and BUILD_TIME and send on response headers
- Add a `Draining` state for LambdaInstances that are waiting to be replaced at before exiting
- Add an instance count lock (this is infrequently accessed)

## Extension
- Return from requests that were sent more than 5 seconds ago
- Prevent the ping loop from exiting before connections are even established to the router