### PR TITLE
Various refactorings, improvements. 

### DIFF
--- a/extension/src/app_request.rs
+++ b/extension/src/app_request.rs
@@ -1,6 +1,7 @@
 use std::pin::Pin;
 use std::str::FromStr;
 
+use crate::prelude::*;
 use hyper::body::Body;
 use hyper::header::HeaderName;
 use hyper::{body::Incoming, Request};
@@ -18,7 +19,7 @@ pub async fn read_until_req_headers(
   res_stream: &mut Incoming,
   lambda_id: &str,
   channel_id: &str,
-) -> anyhow::Result<(hyper::http::request::Builder, bool, Vec<u8>)> {
+) -> Result<(hyper::http::request::Builder, bool, Vec<u8>)> {
   let mut buf = Vec::<u8>::with_capacity(32 * 1024);
 
   while let Some(chunk) =

--- a/extension/src/app_start.rs
+++ b/extension/src/app_start.rs
@@ -105,10 +105,7 @@ pub async fn health_check_contained_app(
 
     let usable_sender = sender.as_mut().unwrap();
 
-    if futures::future::poll_fn(|ctx| usable_sender.poll_ready(ctx))
-      .await
-      .is_err()
-    {
+    if usable_sender.ready().await.is_err() {
       // The connection has errored
       sender.take();
       conn.take();

--- a/extension/src/endpoint.rs
+++ b/extension/src/endpoint.rs
@@ -1,0 +1,182 @@
+use crate::prelude::*;
+use hyper::Uri;
+use rustls_pki_types::ServerName;
+use std::{borrow::Cow, str::FromStr, sync::Arc};
+
+/// An `Endpoint` type to extract and validate the interesting components from a hyper `Uri`, and
+/// make them relatively cheap to clone.
+#[derive(Debug, Clone)]
+pub struct Endpoint {
+  scheme: Scheme,
+  host: Arc<str>,
+  port: u16,
+}
+
+impl Endpoint {
+  pub fn new<T>(scheme: Scheme, host: T, port: u16) -> Self
+  where
+    T: Into<Arc<str>>,
+  {
+    Self {
+      scheme,
+      host: host.into(),
+      port,
+    }
+  }
+
+  /// Construct an [`Endpoint`] from a [`Uri`].
+  fn from_uri(uri: &Uri) -> Result<Self, Error> {
+    let scheme: Scheme = uri.try_into()?;
+    let host = uri
+      .host()
+      .with_context(|| format!("could not determine host from url '{}'", uri))?;
+    let port = uri.port_u16().unwrap_or(scheme.default_port());
+
+    Ok(Self {
+      scheme,
+      host: host.into(),
+      port,
+    })
+  }
+
+  pub fn scheme(&self) -> Scheme {
+    self.scheme
+  }
+
+  pub fn host(&self) -> &str {
+    &self.host
+  }
+
+  pub fn port(&self) -> u16 {
+    self.port
+  }
+
+  /// Formats a host request header that specifies the host and port number of the server to which
+  /// the request is being sent. If the [`Endpoint`]'s port is the default port for the service, the
+  /// host can be used directly without allocating a new string.
+  ///
+  /// See [mozilla dev docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host):
+  /// If no port is included, the default port for the service requested is implied (e.g., 443 for
+  /// an HTTPS URL, and 80 for an HTTP URL).
+  pub fn host_header(&self) -> Cow<'_, str> {
+    if self.port == self.scheme.default_port() {
+      Cow::Borrowed(&self.host)
+    } else {
+      format!("{}:{}", &self.host, self.port).into()
+    }
+  }
+
+  pub fn socket_addr_coercable(&self) -> (&str, u16) {
+    (self.host(), self.port)
+  }
+}
+
+impl TryFrom<&Uri> for Endpoint {
+  type Error = Error;
+
+  fn try_from(uri: &Uri) -> Result<Self, Self::Error> {
+    Self::from_uri(uri)
+  }
+}
+
+impl TryFrom<Uri> for Endpoint {
+  type Error = Error;
+
+  fn try_from(uri: Uri) -> Result<Self, Self::Error> {
+    Self::from_uri(&uri)
+  }
+}
+
+impl FromStr for Endpoint {
+  type Err = Error;
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    let uri: Uri = s.parse()?;
+    uri.try_into()
+  }
+}
+
+impl TryFrom<Endpoint> for ServerName<'_> {
+  type Error = Error;
+  fn try_from(endpoint: Endpoint) -> Result<Self, Self::Error> {
+    Ok(ServerName::try_from(endpoint.host().to_owned())?)
+  }
+}
+
+impl<'a> TryFrom<&'a Endpoint> for ServerName<'a> {
+  type Error = Error;
+  fn try_from(endpoint: &'a Endpoint) -> Result<Self, Self::Error> {
+    Ok(ServerName::try_from(endpoint.host())?)
+  }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub enum Scheme {
+  #[default]
+  Http,
+  Https,
+}
+
+impl Scheme {
+  pub fn as_str(&self) -> &str {
+    match self {
+      Scheme::Http => "http",
+      Scheme::Https => "https",
+    }
+  }
+
+  pub fn default_port(&self) -> u16 {
+    match self {
+      Scheme::Http => 80,
+      Scheme::Https => 443,
+    }
+  }
+}
+
+impl AsRef<str> for Scheme {
+  fn as_ref(&self) -> &str {
+    self.as_str()
+  }
+}
+
+impl TryFrom<&Uri> for Scheme {
+  type Error = Error;
+  fn try_from(uri: &Uri) -> Result<Self, Self::Error> {
+    match uri.scheme().map(|s| s.as_str()) {
+      Some("https") => Ok(Scheme::Https),
+      Some("http") => Ok(Scheme::Http),
+      _ => anyhow::bail!(
+        "'{}' has an invalid scheme, only 'http' and 'https' are supported",
+        uri
+      ),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_host_header_with_default_port() {
+    let endpoint: Endpoint = "http://example.com:80".parse().unwrap();
+
+    assert_eq!(endpoint.host_header(), Cow::Borrowed("example.com"))
+  }
+
+  #[test]
+  fn test_host_header_without_port() {
+    let endpoint: Endpoint = "http://example.com".parse().unwrap();
+
+    assert_eq!(endpoint.host_header(), Cow::Borrowed("example.com"))
+  }
+
+  #[test]
+  fn test_host_header_custom_port() {
+    let endpoint: Endpoint = "http://example.com:8080".parse().unwrap();
+
+    assert_eq!(
+      endpoint.host_header(),
+      Cow::Owned::<String>("example.com:8080".to_string())
+    )
+  }
+}

--- a/extension/src/lambda_request.rs
+++ b/extension/src/lambda_request.rs
@@ -1,19 +1,26 @@
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::{pin::Pin, sync::Arc};
 
-use hyper::Uri;
+use http_body_util::combinators::BoxBody;
+use hyper::{
+  body::Bytes,
+  client::conn::http2::{self, SendRequest},
+};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use rand::SeedableRng;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::net::TcpStream;
+use rustls_pki_types::ServerName;
+use tokio::{
+  io::{AsyncRead, AsyncWrite},
+  net::TcpStream,
+};
+use tokio_rustls::{client::TlsStream, TlsConnector};
 
 use crate::cert::AcceptAnyServerCert;
+use crate::endpoint::{Endpoint, Scheme};
 use crate::ping;
 use crate::prelude::*;
 use crate::router_channel::RouterChannel;
 use crate::time::current_time_millis;
-
-use tokio_rustls::client::TlsStream;
 
 // Define a Stream trait that both TlsStream and TcpStream implement
 pub trait Stream: AsyncRead + AsyncWrite + Send {}
@@ -25,11 +32,11 @@ impl Stream for TcpStream {}
 /// this is torn down completely
 #[derive(Debug, Clone)]
 pub struct LambdaRequest {
-  domain: Uri,
+  app_endpoint: Endpoint,
   compression: bool,
   lambda_id: LambdaId,
   channel_count: u8,
-  dispatcher_url: Uri,
+  router_endpoint: Endpoint,
   cancel_token: tokio_util::sync::CancellationToken,
   deadline_ms: u64,
   goaway_received: Arc<AtomicBool>,
@@ -46,20 +53,20 @@ impl LambdaRequest {
   /// * `deadline_ms`: A timestamp in milliseconds since the Unix epoch representing when the
   /// Lambda function needs to finish execution.
   pub fn new(
-    domain: Uri,
+    app_endpoint: Endpoint,
     compression: bool,
     lambda_id: LambdaId,
     channel_count: u8,
-    dispatcher_url: Uri,
+    router_endpoint: Endpoint,
     deadline_ms: u64,
   ) -> Self {
     LambdaRequest {
       count: Arc::new(AtomicUsize::new(0)),
-      domain,
+      app_endpoint,
       compression,
       lambda_id,
       channel_count,
-      dispatcher_url,
+      router_endpoint,
       cancel_token: tokio_util::sync::CancellationToken::new(),
       deadline_ms,
       goaway_received: Arc::new(AtomicBool::new(false)),
@@ -72,78 +79,18 @@ impl LambdaRequest {
   /// Executes a task with a specified deadline.
   pub async fn start(&mut self) -> Result<(), Error> {
     let start_time = current_time_millis();
-    let scheme = self.dispatcher_url.scheme().unwrap().to_string();
-    let use_https = scheme == "https";
-    let host = self
-      .dispatcher_url
-      .host()
-      .expect("uri has no host")
-      .to_string();
-    let port = self.dispatcher_url.port_u16().unwrap_or(80);
-    let addr = format!("{}:{}", host, port);
-    let dispatcher_authority = self.dispatcher_url.authority().unwrap().clone();
 
-    // Setup the connection to the router
-    let tcp_stream = TcpStream::connect(addr).await?;
-    tcp_stream.set_nodelay(true)?;
-
-    let mut root_cert_store = rustls::RootCertStore::empty();
-    for cert in rustls_native_certs::load_native_certs()? {
-      root_cert_store.add(cert).ok(); // ignore error
-    }
-    let mut config = rustls::ClientConfig::builder()
-      .with_root_certificates(root_cert_store)
-      .with_no_client_auth();
-    // We're going to accept non-validatable certificates
-    config
-      .dangerous()
-      .set_certificate_verifier(Arc::new(AcceptAnyServerCert));
-    // Advertise http2
-    config.alpn_protocols = vec![b"h2".to_vec()];
-    let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
-    let domain_host = self.dispatcher_url.host().ok_or("Host not found").unwrap();
-    let domain = rustls_pki_types::ServerName::try_from(domain_host)?;
-
-    let stream: Box<dyn Stream + Unpin>;
-    if use_https {
-      let tls_stream = connector.connect(domain.to_owned(), tcp_stream).await?;
-      stream = Box::new(tls_stream);
-    } else {
-      stream = Box::new(tcp_stream);
-    }
-    let io = TokioIo::new(Pin::new(stream));
-
-    // Setup the HTTP2 connection
-    let (sender, conn) = hyper::client::conn::http2::handshake(TokioExecutor::new(), io)
-      .await
-      .unwrap();
-
-    let lambda_id_clone = Arc::clone(&self.lambda_id);
-    tokio::task::spawn(async move {
-      if let Err(err) = conn.await {
-        log::error!(
-          "LambdaId: {} - Router HTTP2 connection failed: {:?}",
-          lambda_id_clone,
-          err
-        );
-      }
-    });
-
-    let app_url: Uri = self.domain.clone();
+    let sender =
+      connect_to_router(self.router_endpoint.clone(), Arc::clone(&self.lambda_id)).await?;
 
     // Send the ping requests in background
-    let scheme_clone = scheme.clone();
-    let host_clone = host.clone();
     let ping_task = tokio::task::spawn(ping::send_ping_requests(
       Arc::clone(&self.last_active),
       Arc::clone(&self.goaway_received),
-      dispatcher_authority.to_string(),
       sender.clone(),
       Arc::clone(&self.lambda_id),
       Arc::clone(&self.count),
-      scheme_clone,
-      host_clone,
-      port,
+      self.router_endpoint.clone(),
       self.deadline_ms,
       self.cancel_token.clone(),
       Arc::clone(&self.requests_in_flight),
@@ -152,40 +99,22 @@ impl LambdaRequest {
     // Startup the request channels
     let futures = (0..self.channel_count)
       .map(|channel_number| {
-        let app_url = app_url.clone();
-        let compression_enabled = self.compression;
         let last_active = Arc::clone(&self.last_active);
-        let goaway_received = Arc::clone(&self.goaway_received);
-        let dispatcher_authority = dispatcher_authority.clone();
-        let sender = sender.clone();
-        let count = Arc::clone(&self.count);
-        let rng = self.rng.clone();
-        let scheme = scheme.clone();
-        let host = host.clone();
-        let lambda_id = Arc::clone(&self.lambda_id);
-        let requests_in_flight = Arc::clone(&self.requests_in_flight);
-
         // Create a JoinHandle and implicitly return it to be collected in the vector
-        tokio::spawn(async move {
-          let mut router_channel = RouterChannel::new(
-            Arc::clone(&count),
-            compression_enabled,
-            lambda_id,
-            Arc::clone(&goaway_received),
-            Arc::clone(&last_active),
-            rng,
-            Arc::clone(&requests_in_flight),
-            scheme,
-            host,
-            port,
-            app_url,
-            channel_number,
-            sender,
-            dispatcher_authority,
-          );
-
-          router_channel.start().await
-        })
+        let mut router_channel = RouterChannel::new(
+          Arc::clone(&self.count),
+          self.compression,
+          Arc::clone(&self.goaway_received),
+          Arc::clone(&last_active),
+          self.rng.clone(),
+          Arc::clone(&self.requests_in_flight),
+          self.router_endpoint.clone(),
+          self.app_endpoint.clone(),
+          channel_number,
+          sender.clone(),
+          Arc::clone(&self.lambda_id),
+        );
+        tokio::spawn(async move { router_channel.start().await })
       })
       .collect::<Vec<_>>();
 
@@ -222,4 +151,52 @@ impl LambdaRequest {
 
     Ok(())
   }
+}
+async fn connect_to_router(
+  router_endpoint: Endpoint,
+  lambda_id: LambdaId,
+) -> Result<SendRequest<BoxBody<Bytes, Error>>, Error> {
+  let tcp_stream = TcpStream::connect(router_endpoint.socket_addr_coercable()).await?;
+  tcp_stream.set_nodelay(true)?;
+
+  let stream: Box<dyn Stream + Unpin> = match router_endpoint.scheme() {
+    Scheme::Https => {
+      let mut root_cert_store = rustls::RootCertStore::empty();
+      for cert in rustls_native_certs::load_native_certs()? {
+        root_cert_store.add(cert).ok(); // ignore error
+      }
+      let mut config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_cert_store)
+        .with_no_client_auth();
+      // We're going to accept non-validatable certificates
+      config
+        .dangerous()
+        .set_certificate_verifier(Arc::new(AcceptAnyServerCert));
+      // Advertise http2
+      config.alpn_protocols = vec![b"h2".to_vec()];
+      let connector = TlsConnector::from(Arc::new(config));
+      let domain = ServerName::try_from(router_endpoint)?;
+      let tls_stream = connector.connect(domain, tcp_stream).await?;
+      Box::new(tls_stream)
+    }
+    Scheme::Http => Box::new(tcp_stream),
+  };
+
+  let io = TokioIo::new(Pin::new(stream));
+
+  // Setup the HTTP2 connection
+  let (sender, conn) = http2::handshake(TokioExecutor::new(), io)
+    .await
+    .context("failed to setup HTTP2 connection to the router")?;
+
+  tokio::task::spawn(async move {
+    if let Err(err) = conn.await {
+      log::error!(
+        "LambdaId: {} - Router HTTP2 connection failed: {:?}",
+        lambda_id,
+        err
+      );
+    }
+  });
+  Ok(sender)
 }

--- a/extension/src/lambda_request.rs
+++ b/extension/src/lambda_request.rs
@@ -27,7 +27,7 @@ impl Stream for TcpStream {}
 pub struct LambdaRequest {
   domain: Uri,
   compression: bool,
-  lambda_id: String,
+  lambda_id: LambdaId,
   channel_count: u8,
   dispatcher_url: Uri,
   cancel_token: tokio_util::sync::CancellationToken,
@@ -48,7 +48,7 @@ impl LambdaRequest {
   pub fn new(
     domain: Uri,
     compression: bool,
-    lambda_id: String,
+    lambda_id: LambdaId,
     channel_count: u8,
     dispatcher_url: Uri,
     deadline_ms: u64,
@@ -118,7 +118,7 @@ impl LambdaRequest {
       .await
       .unwrap();
 
-    let lambda_id_clone = self.lambda_id.clone();
+    let lambda_id_clone = Arc::clone(&self.lambda_id);
     tokio::task::spawn(async move {
       if let Err(err) = conn.await {
         log::error!(
@@ -139,7 +139,7 @@ impl LambdaRequest {
       Arc::clone(&self.goaway_received),
       dispatcher_authority.to_string(),
       sender.clone(),
-      self.lambda_id.clone(),
+      Arc::clone(&self.lambda_id),
       Arc::clone(&self.count),
       scheme_clone,
       host_clone,
@@ -162,7 +162,7 @@ impl LambdaRequest {
         let rng = self.rng.clone();
         let scheme = scheme.clone();
         let host = host.clone();
-        let lambda_id = self.lambda_id.clone();
+        let lambda_id = Arc::clone(&self.lambda_id);
         let requests_in_flight = Arc::clone(&self.requests_in_flight);
 
         // Create a JoinHandle and implicitly return it to be collected in the vector

--- a/extension/src/lambda_service.rs
+++ b/extension/src/lambda_service.rs
@@ -66,7 +66,7 @@ impl LambdaService {
     }
 
     // extract some useful info from the request
-    let lambda_id = event.payload.id;
+    let lambda_id: LambdaId = event.payload.id.into();
     let channel_count: u8 = event.payload.number_of_channels;
     let dispatcher_url = event.payload.dispatcher_url;
 

--- a/extension/src/main.rs
+++ b/extension/src/main.rs
@@ -18,6 +18,7 @@ mod app_request;
 mod app_start;
 mod cert;
 mod counter_drop;
+mod endpoint;
 mod lambda_request;
 mod lambda_service;
 mod messages;
@@ -152,7 +153,7 @@ async fn async_main(options: Options) -> Result<()> {
 
     match result {
       Ok(success) => {
-        if success == false {
+        if !success {
           log::info!("Health check - returned false before timeout, deferring init to handler");
           goaway_received.store(true, Ordering::SeqCst);
         }

--- a/extension/src/main.rs
+++ b/extension/src/main.rs
@@ -74,7 +74,7 @@ fn main() -> Result<()> {
         .worker_threads(worker_threads)
         .build()
         .unwrap();
-      runtime.block_on(async_main(&options))?;
+      runtime.block_on(async_main(options))?;
     }
     Runtime::DefaultMultiThread => {
       log::info!("Using default_multi_thread runtime");
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
         .enable_all()
         .build()
         .unwrap();
-      runtime.block_on(async_main(&options))?;
+      runtime.block_on(async_main(options))?;
     }
     // Default or `current_thread` runtime
     Runtime::CurrentThread => {
@@ -92,14 +92,14 @@ fn main() -> Result<()> {
         .enable_all()
         .build()
         .unwrap();
-      runtime.block_on(async_main(&options))?;
+      runtime.block_on(async_main(options))?;
     }
   }
 
   Ok(())
 }
 
-async fn async_main(options: &Options) -> Result<()> {
+async fn async_main(options: Options) -> Result<()> {
   let mut term_signal = signal(SignalKind::terminate())?;
 
   let thread_count = threads::get_threads();
@@ -169,11 +169,9 @@ async fn async_main(options: &Options) -> Result<()> {
   };
 
   let svc = LambdaService::new(
-    options.compression,
+    options,
     Arc::new(AtomicBool::new(initialized)),
-    options.port,
     healthcheck_url,
-    options.local_env,
   );
 
   tokio::select! {

--- a/extension/src/main.rs
+++ b/extension/src/main.rs
@@ -12,6 +12,7 @@ use tokio::time::timeout;
 
 use crate::lambda_service::LambdaService;
 use crate::options::{Options, Runtime};
+use crate::prelude::*;
 
 mod app_request;
 mod app_start;
@@ -22,11 +23,12 @@ mod lambda_service;
 mod messages;
 mod options;
 mod ping;
+pub mod prelude;
 mod router_channel;
 mod threads;
 mod time;
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<()> {
   env_logger::Builder::new()
     .format(|buf, record| {
       writeln!(
@@ -97,7 +99,7 @@ fn main() -> anyhow::Result<()> {
   Ok(())
 }
 
-async fn async_main(options: &Options) -> anyhow::Result<()> {
+async fn async_main(options: &Options) -> Result<()> {
   let mut term_signal = signal(SignalKind::terminate())?;
 
   let thread_count = threads::get_threads();
@@ -137,7 +139,7 @@ async fn async_main(options: &Options) -> anyhow::Result<()> {
 
   let healthcheck_url: Uri = format!("http://127.0.0.1:{}/health", options.port)
     .parse()
-    .unwrap();
+    .expect("healthcheck url with port should always be valid");
 
   // Wait for the contained app to be ready
   let initialized = if options.async_init {

--- a/extension/src/messages.rs
+++ b/extension/src/messages.rs
@@ -6,7 +6,7 @@ pub struct WaiterRequest {
   #[serde(rename = "Id")]
   pub id: String,
   #[serde(rename = "DispatcherUrl")]
-  pub dispatcher_url: String,
+  pub router_url: String,
   #[serde(rename = "NumberOfChannels")]
   pub number_of_channels: u8,
   #[serde(rename = "SentTime")]

--- a/extension/src/options.rs
+++ b/extension/src/options.rs
@@ -1,3 +1,4 @@
+use crate::prelude::*;
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum Runtime {
   #[default]

--- a/extension/src/options.rs
+++ b/extension/src/options.rs
@@ -1,4 +1,6 @@
 use crate::prelude::*;
+use std::time::Duration;
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum Runtime {
   #[default]
@@ -33,16 +35,23 @@ impl EnvVarProvider for RealEnvVarProvider {
   }
 }
 
+#[derive(Clone, Copy)]
 pub struct Options {
   pub port: u16,
   pub async_init: bool,
   pub compression: bool,
   pub runtime: Runtime,
   pub local_env: bool,
+  pub force_deadline_secs: Option<Duration>,
 }
 
 impl Options {
   fn from_env<P: EnvVarProvider>(provider: P) -> Self {
+    let force_deadline_secs = provider
+      .get_var("LAMBDA_DISPATCH_FORCE_DEADLINE")
+      .ok()
+      .and_then(|d| d.parse::<u64>().map(Duration::from_secs).ok());
+
     Options {
       port: provider
         .get_var("LAMBDA_DISPATCH_PORT")
@@ -64,6 +73,7 @@ impl Options {
         .ok()
         .map_or(Runtime::CurrentThread, |v| v.into()),
       local_env: provider.get_var("LAMBDA_DISPATCH_FORCE_DEADLINE").is_ok(),
+      force_deadline_secs,
     }
   }
 }
@@ -109,10 +119,11 @@ mod tests {
     };
 
     assert_eq!(options.port, 9000);
-    assert_eq!(options.async_init, true);
-    assert_eq!(options.compression, false);
+    assert!(options.async_init);
+    assert!(!options.compression);
     assert_eq!(options.runtime, Runtime::MultiThread);
-    assert_eq!(options.local_env, true);
+    assert!(options.local_env);
+    assert_eq!(options.force_deadline_secs, None);
   }
 
   #[test]
@@ -134,18 +145,18 @@ mod tests {
           "60".to_string(),
         ),
       ]
-      .iter()
-      .cloned()
+      .into_iter()
       .collect(),
     };
 
     let options = Options::from_env(mock_provider);
 
     assert_eq!(options.port, 4000);
-    assert_eq!(options.async_init, true);
-    assert_eq!(options.compression, false);
+    assert!(options.async_init);
+    assert!(!options.compression);
     assert_eq!(options.runtime, Runtime::CurrentThread);
-    assert_eq!(options.local_env, true);
+    assert!(options.local_env);
+    assert_eq!(options.force_deadline_secs, Some(Duration::from_secs(60)));
   }
 
   #[test]
@@ -167,17 +178,17 @@ mod tests {
           "invalid".to_string(),
         ),
       ]
-      .iter()
-      .cloned()
+      .into_iter()
       .collect(),
     };
 
     let options = Options::from_env(mock_provider);
 
     assert_eq!(options.port, 3001); // Default value
-    assert_eq!(options.async_init, false); // Default value
-    assert_eq!(options.compression, true); // Default value
+    assert!(!options.async_init); // Default value
+    assert!(options.compression); // Default value
     assert_eq!(options.runtime, Runtime::CurrentThread); // Default value
-    assert_eq!(options.local_env, true); // Default value
+    assert!(options.local_env); // Default value
+    assert_eq!(options.force_deadline_secs, None);
   }
 }

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -1,18 +1,20 @@
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::time::{Duration, SystemTime};
-use std::{pin::Pin, sync::Arc};
+use std::{
+  sync::{
+    atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    Arc,
+  },
+  time::{Duration, SystemTime},
+};
 
 use futures::channel::mpsc;
 use futures::SinkExt;
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, StreamBody};
 use httpdate::fmt_http_date;
-use hyper::body::Body;
-use hyper::client::conn::http2::SendRequest;
-use hyper::StatusCode;
 use hyper::{
-  body::{Bytes, Frame, Incoming},
-  Request,
+  body::{Bytes, Frame},
+  client::conn::http2::SendRequest,
+  Request, StatusCode,
 };
 
 use crate::prelude::*;

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -25,7 +25,7 @@ pub async fn send_ping_requests(
   goaway_received: Arc<AtomicBool>,
   authority: String,
   mut sender: SendRequest<BoxBody<Bytes, Error>>,
-  lambda_id: String,
+  lambda_id: LambdaId,
   count: Arc<AtomicUsize>,
   scheme: String,
   host: String,
@@ -100,7 +100,7 @@ pub async fn send_ping_requests(
         .method("GET")
         .header(hyper::header::DATE, fmt_http_date(SystemTime::now()))
         .header(hyper::header::HOST, authority.as_str())
-        .header("X-Lambda-Id", &lambda_id)
+        .header("X-Lambda-Id", lambda_id.as_ref())
         .body(boxed_close_body)
         .unwrap();
 
@@ -145,7 +145,7 @@ pub async fn send_ping_requests(
         .method("GET")
         .header(hyper::header::DATE, fmt_http_date(SystemTime::now()))
         .header(hyper::header::HOST, authority.as_str())
-        .header("X-Lambda-Id", &lambda_id)
+        .header("X-Lambda-Id", lambda_id.as_ref())
         .body(boxed_ping_body)
         .unwrap();
 

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -15,15 +15,14 @@ use hyper::{
   Request,
 };
 
+use crate::prelude::*;
 use crate::time;
-
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 pub async fn send_ping_requests(
   last_active: Arc<AtomicU64>,
   goaway_received: Arc<AtomicBool>,
   authority: String,
-  mut sender: SendRequest<BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>>,
+  mut sender: SendRequest<BoxBody<Bytes, Error>>,
   lambda_id: String,
   count: Arc<AtomicUsize>,
   scheme: String,

--- a/extension/src/prelude.rs
+++ b/extension/src/prelude.rs
@@ -1,1 +1,4 @@
+use std::sync::Arc;
+
 pub use anyhow::{Context, Error, Result};
+pub type LambdaId = Arc<str>;

--- a/extension/src/prelude.rs
+++ b/extension/src/prelude.rs
@@ -1,0 +1,1 @@
+pub use anyhow::{Context, Error, Result};

--- a/extension/src/router_channel.rs
+++ b/extension/src/router_channel.rs
@@ -14,55 +14,45 @@ use hyper::{
   Request, Uri,
 };
 use hyper_util::rt::TokioIo;
+use mpsc::Receiver;
 use rand::prelude::*;
-use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 
 use crate::app_request;
 use crate::counter_drop::DecrementOnDrop;
+use crate::endpoint::Endpoint;
 use crate::time;
 
-use tokio_rustls::client::TlsStream;
-
 use flate2::write::GzEncoder;
-
-// Define a Stream trait that both TlsStream and TcpStream implement
-pub trait Stream: AsyncRead + AsyncWrite + Send {}
-impl Stream for TlsStream<TcpStream> {}
-impl Stream for TcpStream {}
 
 #[derive(Clone)]
 pub struct RouterChannel {
   count: Arc<AtomicUsize>,
   compression: bool,
-  lambda_id: LambdaId,
   goaway_received: Arc<AtomicBool>,
   last_active: Arc<AtomicU64>,
   requests_in_flight: Arc<AtomicUsize>,
   channel_url: Uri,
   channel_id: String,
-  app_url: Uri,
+  app_endpoint: Endpoint,
   channel_number: u8,
   sender: http2::SendRequest<BoxBody<Bytes, Error>>,
-  dispatcher_authority: hyper::http::uri::Authority,
+  lambda_id: LambdaId,
 }
 
 impl RouterChannel {
   pub fn new(
     count: Arc<AtomicUsize>,
     compression: bool,
-    lambda_id: LambdaId,
     goaway_received: Arc<AtomicBool>,
     last_active: Arc<AtomicU64>,
     mut rng: rand::rngs::StdRng,
     requests_in_flight: Arc<AtomicUsize>,
-    router_schema: String,
-    router_host: String,
-    router_port: u16,
-    app_url: Uri,
+    router_endpoint: Endpoint,
+    app_endpoint: Endpoint,
     channel_number: u8,
     sender: http2::SendRequest<BoxBody<Bytes, Error>>,
-    dispatcher_authority: hyper::http::uri::Authority,
+    lambda_id: LambdaId,
   ) -> Self {
     let channel_id = uuid::Builder::from_random_bytes(rng.gen())
       .into_uuid()
@@ -70,7 +60,11 @@ impl RouterChannel {
 
     let channel_url = format!(
       "{}://{}:{}/api/chunked/request/{}/{}",
-      router_schema, router_host, router_port, lambda_id, channel_id
+      router_endpoint.scheme().as_str(),
+      router_endpoint.host(),
+      router_endpoint.port(),
+      lambda_id,
+      channel_id
     )
     .parse()
     .unwrap();
@@ -78,42 +72,25 @@ impl RouterChannel {
     RouterChannel {
       count,
       compression,
-      lambda_id,
       goaway_received,
       last_active,
       requests_in_flight,
       channel_id,
       channel_url,
-      app_url,
+      app_endpoint,
       channel_number,
       sender,
-      dispatcher_authority,
+      lambda_id,
     }
   }
 
   pub async fn start(&mut self) -> Result<()> {
-    let app_host = self.app_url.host().expect("uri has no host");
-    let app_port = self.app_url.port_u16().unwrap_or(80);
-    let app_addr = format!("{}:{}", app_host, app_port);
-
-    // Setup the contained app connection
-    // This is HTTP/1.1 so we need 1 connection for each worker
-    let app_tcp_stream = TcpStream::connect(app_addr).await?;
-    let app_io = TokioIo::new(app_tcp_stream);
-    let (mut app_sender, app_conn) = http1::handshake(app_io).await?;
-    let lambda_id_clone = Arc::clone(&self.lambda_id);
-    let channel_id_clone = self.channel_id.clone();
-
-    tokio::task::spawn(async move {
-      if let Err(err) = app_conn.await {
-        log::error!(
-          "LambdaId: {}, ChannelId: {} - Contained App connection failed: {:?}",
-          lambda_id_clone,
-          channel_id_clone,
-          err
-        );
-      }
-    });
+    let mut app_sender = connect_to_app(
+      &self.app_endpoint,
+      Arc::clone(&self.lambda_id),
+      self.channel_id.clone(),
+    )
+    .await?;
 
     // This is where HTTP2 loops to make all the requests for a given client and worker
     loop {
@@ -127,7 +104,7 @@ impl RouterChannel {
         .uri(&self.channel_url)
         .method("POST")
         .header(hyper::header::DATE, fmt_http_date(SystemTime::now()))
-        .header(hyper::header::HOST, self.dispatcher_authority.as_str())
+        .header(hyper::header::HOST, self.channel_url.host().unwrap())
         // The content-type that we're sending to the router is opaque
         // as it contains another HTTP request/response, so may start as text
         // with request/headers and then be binary after that - it should not be parsed
@@ -146,10 +123,11 @@ impl RouterChannel {
         self.lambda_id,
         self.channel_id
       );
-      if self.sender.ready().await.is_err() {
-        // This gets hit when the router connection faults
-        panic!("LambdaId: {}, ChannelId: {} - Router connection ready check threw error - connection has disconnected, should reconnect", self.lambda_id, self.channel_id);
-      }
+
+      self.sender
+                .ready()
+                .await
+                .context("LambdaId: {}, ChannelId: {} - Router connection ready check threw error - connection has disconnected, should reconnect")?;
 
       let res = self.sender.send_request(req).await?;
       log::debug!(
@@ -509,7 +487,7 @@ impl RouterChannel {
                       // All tasks completed successfully
                   }
                   Err(_) => {
-                      panic!("LambdaId: {}, ChannelId: {} - Error in futures::future::try_join_all", self.lambda_id, channel_id_clone);
+                      panic!("LambdaId: {}, ChannelId: {} - Error in futures::future::try_join_all", &self.lambda_id, channel_id_clone);
                   }
               }
           }
@@ -520,4 +498,27 @@ impl RouterChannel {
 
     Ok(())
   }
+}
+async fn connect_to_app(
+  app_endpoint: &Endpoint,
+  lambda_id: LambdaId,
+  channel_id: String,
+) -> Result<http1::SendRequest<StreamBody<Receiver<Result<Frame<Bytes>>>>>> {
+  // Setup the contained app connection
+  // This is HTTP/1.1 so we need 1 connection for each worker
+  let tcp_stream = TcpStream::connect(app_endpoint.socket_addr_coercable()).await?;
+  let io = TokioIo::new(tcp_stream);
+  let (sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+
+  tokio::task::spawn(async move {
+    if let Err(err) = conn.await {
+      log::error!(
+        "LambdaId: {}, ChannelId: {} - Contained App connection failed: {:?}",
+        lambda_id,
+        channel_id,
+        err
+      );
+    }
+  });
+  Ok(sender)
 }

--- a/extension/src/router_channel.rs
+++ b/extension/src/router_channel.rs
@@ -146,10 +146,7 @@ impl RouterChannel {
         self.lambda_id,
         self.channel_id
       );
-      if futures::future::poll_fn(|ctx| self.sender.poll_ready(ctx))
-        .await
-        .is_err()
-      {
+      if self.sender.ready().await.is_err() {
         // This gets hit when the router connection faults
         panic!("LambdaId: {}, ChannelId: {} - Router connection ready check threw error - connection has disconnected, should reconnect", self.lambda_id, self.channel_id);
       }
@@ -240,10 +237,7 @@ impl RouterChannel {
       let (mut app_req_tx, app_req_recv) = mpsc::channel::<Result<Frame<Bytes>>>(32 * 1024);
       let app_req = app_req_builder.body(StreamBody::new(app_req_recv))?;
 
-      if futures::future::poll_fn(|ctx| app_sender.poll_ready(ctx))
-        .await
-        .is_err()
-      {
+      if app_sender.ready().await.is_err() {
         // This gets hit when the app connection faults
         panic!("LambdaId: {}, ChannelId: {}, Reqs in Flight: {} - App connection ready check threw error - connection has disconnected, should reconnect",
                   self.lambda_id, self.channel_id, self.requests_in_flight.load(std::sync::atomic::Ordering::Acquire));

--- a/extension/src/router_channel.rs
+++ b/extension/src/router_channel.rs
@@ -100,7 +100,7 @@ impl RouterChannel {
     // This is HTTP/1.1 so we need 1 connection for each worker
     let app_tcp_stream = TcpStream::connect(app_addr).await?;
     let app_io = TokioIo::new(app_tcp_stream);
-    let (mut app_sender, app_conn) = hyper::client::conn::http1::handshake(app_io).await?;
+    let (mut app_sender, app_conn) = http1::handshake(app_io).await?;
     let lambda_id_clone = self.lambda_id.clone();
     let channel_id_clone = self.channel_id.clone();
 


### PR DESCRIPTION
This PR contains a variety of changes I made while building my understanding of the code. I some attempt to keep commits focused on a particular change. While reviewing the code, it will probably be helpful to look at each individual commit.

- `f9673cf` fully adopt anyhow errors - Standardizes on `anyhow::{Error, Result}` instead of mixing `std::io::Result` and `dyn Error`. Also makes use of `Context` trait for relaying error messages as results.
- `6340a90` use less boiler plate polling ready - The `ready` function is much less code and does the exact same thing under the hood.
- `2efc781` cleanup unused imports
- `7b5b40c` construct close/ping urls outside of loop - These urls do not change once computed, allocating them before the loop reduces unnecessary allocations.
- `1b606df` make options copyable, parse deadline duration
- `007f5f0` lambda_id is immutable, type alias it as a sharable convenience type
- `a397631` Introduces Endpoint, consistent naming, extracts code clumps
  - Introduces Endpoint helper type for cheaper url formatting/cloning
  - Renames variables to clearly differentiate between app and router
  - Extracts connection setup code clumps

