### PR TITLE
Issue 165 - Improve Router unit test coverage to 60%

### DIFF
--- a/src/PwrDrvr.LambdaDispatch.Extension/Function.cs
+++ b/src/PwrDrvr.LambdaDispatch.Extension/Function.cs
@@ -268,7 +268,7 @@ public class Function
 
             CancellationTokenSource cts = new CancellationTokenSource();
 
-            List<Task> tasks = new List<Task>();
+            List<Task> tasks = [];
             for (int i = 0; i < NumberOfChannels; i++)
             {
                 // Required to get a unique variable that identifies the task
@@ -352,7 +352,7 @@ public class Function
                                         Port = 3001,
                                         // The requestUri is ONLY a path/query string
                                         // TODO: Not sure Path will accept a query string here
-                                        Path = receivedRequest.RequestUri.OriginalString,
+                                        Path = receivedRequest.RequestUri?.OriginalString,
                                         // Query = receivedRequest.RequestUri.Query,
                                         Scheme = "http",
                                     }.Uri;

--- a/src/PwrDrvr.LambdaDispatch.Extension/HttpReverseRequester.cs
+++ b/src/PwrDrvr.LambdaDispatch.Extension/HttpReverseRequester.cs
@@ -93,7 +93,11 @@ public class HttpReverseRequester
 
   private readonly HttpClient _client;
 
-  public HttpReverseRequester(string id, string dispatcherUrl, HttpClient httpClient, ILogger<HttpReverseRequester> logger = null)
+  public HttpReverseRequester(
+    string id,
+    string dispatcherUrl,
+    HttpClient httpClient,
+    ILogger<HttpReverseRequester>? logger = null)
   {
     _logger = logger ?? LoggerInstance.CreateLogger<HttpReverseRequester>();
     _id = id;

--- a/src/PwrDrvr.LambdaDispatch.Extension/MetricsRegistry.cs
+++ b/src/PwrDrvr.LambdaDispatch.Extension/MetricsRegistry.cs
@@ -18,7 +18,7 @@ public class LoggerMetricsReporter : IReportMetrics
 {
   private readonly ILogger _logger = LoggerInstance.CreateLogger<LoggerMetricsReporter>();
 
-  public IFilterMetrics Filter { get; set; }
+  public IFilterMetrics? Filter { get; set; }
   public TimeSpan FlushInterval { get; set; }
   public IMetricsOutputFormatter Formatter { get; set; }
 

--- a/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
@@ -117,6 +117,7 @@ public class ChunkedController : ControllerBase
           await Response.WriteAsync("No X-Lambda-Id header");
           await Response.CompleteAsync();
           try { await Request.Body.CopyToAsync(Stream.Null); } catch { }
+          return;
         }
 
         // Log an error if the request was delayed in reaching us, using the Date header added by HttpClient
@@ -200,6 +201,7 @@ public class ChunkedController : ControllerBase
           await Response.CompleteAsync();
           try { await Request.Body.CopyToAsync(Stream.Null); } catch { }
           logger.LogDebug("Router.ChunkedController.Post - Pool not found for X-PoolId: {}, closed", poolId);
+          return;
         }
       }
       catch (Exception ex)

--- a/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
@@ -31,7 +31,7 @@ public class ChunkedController : ControllerBase
     if (Request.Headers.TryGetValue("X-Pool-Id",
         out Microsoft.Extensions.Primitives.StringValues poolIdMulti) && poolIdMulti.Count == 1)
     {
-      poolId = poolIdMulti[0] ?? poolId;
+      poolId = !string.IsNullOrWhiteSpace(poolIdMulti[0]) ? poolIdMulti[0] : poolId;
     }
 
     return poolId;

--- a/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
@@ -17,12 +17,17 @@ public class ChunkedController : ControllerBase
   private readonly ILogger<ChunkedController> logger;
   private readonly IMetricsLogger metricsLogger;
   private readonly IPoolManager poolManager;
+  private readonly IMetricsRegistry metricsRegistry;
 
-  public ChunkedController(IPoolManager poolManager, IMetricsLogger metricsLogger, ILogger<ChunkedController> logger)
+  public ChunkedController(IPoolManager poolManager,
+    IMetricsLogger metricsLogger,
+    ILogger<ChunkedController> logger,
+    IMetricsRegistry metricsRegistry)
   {
     this.poolManager = poolManager;
     this.logger = logger;
     this.metricsLogger = metricsLogger;
+    this.metricsRegistry = metricsRegistry;
   }
 
   private string GetPoolId()
@@ -104,7 +109,7 @@ public class ChunkedController : ControllerBase
   {
     logger.LogDebug("Router.ChunkedController.Post - Start for LambdaId: {lambdaId}, ChannelId: {channelId}", lambdaId, channelId);
 
-    using (MetricsRegistry.Metrics.Measure.Timer.Time(MetricsRegistry.LambdaRequestTimer))
+    using (metricsRegistry.Metrics.Measure.Timer.Time(metricsRegistry.LambdaRequestTimer))
     {
       try
       {
@@ -166,7 +171,7 @@ public class ChunkedController : ControllerBase
           {
             try
             {
-              MetricsRegistry.Metrics.Measure.Counter.Increment(MetricsRegistry.LambdaConnectionRejectedCount);
+              metricsRegistry.Metrics.Measure.Counter.Increment(metricsRegistry.LambdaConnectionRejectedCount);
               logger.LogDebug("Router.ChunkedController.Post - No LambdaInstance found for X-Pool-Id: {}, X-Lambda-Id: {}, X-Channel-Id: {}, closing", poolId, lambdaId, channelId);
               // Only in this case can we close the response because it hasn't been started
               // Have to write the response body first since the Lambda

--- a/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ChunkedController.cs
@@ -32,11 +32,14 @@ public class ChunkedController : ControllerBase
 
   private string GetPoolId()
   {
-    var poolId = "default";
+    string poolId = "default";
     if (Request.Headers.TryGetValue("X-Pool-Id",
-        out Microsoft.Extensions.Primitives.StringValues poolIdMulti) && poolIdMulti.Count == 1)
+          out Microsoft.Extensions.Primitives.StringValues poolIdMulti)
+        && poolIdMulti.Count == 1
+        && poolIdMulti[0] != null
+        && !string.IsNullOrWhiteSpace(poolIdMulti[0]))
     {
-      poolId = !string.IsNullOrWhiteSpace(poolIdMulti[0]) ? poolIdMulti[0] : poolId;
+      poolId = poolIdMulti[0] ?? poolId;
     }
 
     return poolId;

--- a/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/DefaultController.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/DefaultController.cs
@@ -10,7 +10,7 @@ namespace PwrDrvr.LambdaDispatch.Router.ControlChannels.Controllers;
 [Route("{*url}")]
 public class DefaultController : ControllerBase
 {
-  public async void HandleRequest()
+  public async Task HandleRequest()
   {
     Console.WriteLine("Router.ControlChannels.Controllers.DefaultController.HandleRequest - Start");
     Response.StatusCode = 404;

--- a/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ResetController.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ResetController.cs
@@ -10,9 +10,16 @@ namespace PwrDrvr.LambdaDispatch.Router.ControlChannels.Controllers;
 [Route("/reset")]
 public class ResetController : ControllerBase
 {
+  private readonly IMetricsRegistry _metricsRegistry;
+
+  public ResetController(IMetricsRegistry metricsRegistry)
+  {
+    _metricsRegistry = metricsRegistry;
+  }
+
   public void HandleRequest()
   {
-    MetricsRegistry.Reset();
+    _metricsRegistry.Reset();
     Ok();
   }
 }

--- a/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ResetController.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Areas/ControlChannels/Controllers/ResetController.cs
@@ -1,7 +1,3 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Mvc;
 
 namespace PwrDrvr.LambdaDispatch.Router.ControlChannels.Controllers;

--- a/src/PwrDrvr.LambdaDispatch.Router/Config.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Config.cs
@@ -159,6 +159,10 @@ public class Config : IConfig
     {
       throw new ApplicationException($"Invalid IncomingRequestHTTPSPort in configuration: {IncomingRequestHTTPSPort}");
     }
+    if (ControlChannelInsecureHTTP2Port < 1 || ControlChannelInsecureHTTP2Port > 65535)
+    {
+      throw new ApplicationException($"Invalid ControlChannelInsecureHTTP2Port in configuration: {ControlChannelHTTP2Port}");
+    }
     if (ControlChannelHTTP2Port < 1 || ControlChannelHTTP2Port > 65535)
     {
       throw new ApplicationException($"Invalid ControlChannelHTTP2Port in configuration: {ControlChannelHTTP2Port}");
@@ -206,6 +210,11 @@ public class Config : IConfig
     else if (InstanceCountMultiplier > 10)
     {
       throw new ApplicationException($"InstanceCountMultiplier must be less than or equal to 10");
+    }
+
+    if (!string.IsNullOrWhiteSpace(EnvVarForCallbackIp) && !Regex.IsMatch(EnvVarForCallbackIp, @"^[a-zA-Z_][a-zA-Z0-9_]*$"))
+    {
+      throw new ApplicationException($"Invalid EnvVarForCallbackIp in configuration: {EnvVarForCallbackIp}");
     }
   }
 }

--- a/src/PwrDrvr.LambdaDispatch.Router/Dispatcher.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Dispatcher.cs
@@ -6,7 +6,7 @@ namespace PwrDrvr.LambdaDispatch.Router;
 
 public class DispatcherAddConnectionResult
 {
-  public LambdaConnection? Connection { get; set; }
+  public ILambdaConnection? Connection { get; set; }
   public bool ImmediatelyDispatched { get; set; } = false;
 
   public bool LambdaIDNotFound { get; set; } = false;
@@ -18,7 +18,7 @@ public class DispatcherAddConnectionResult
 /// </summary>
 public interface IBackgroundDispatcher
 {
-  void WakeupBackgroundDispatcher(LambdaConnection? connection);
+  void WakeupBackgroundDispatcher(ILambdaConnection? connection);
 }
 
 public interface IDispatcher
@@ -57,7 +57,7 @@ public class Dispatcher : IDispatcher, IBackgroundDispatcher
   /// The background dispatcher will pick these up and either use them or add them to the LOQ using
   /// ReenqueueUnusedConnection() in that case.
   /// </summary>
-  private readonly BlockingCollection<LambdaConnection?> _newConnections = [];
+  private readonly BlockingCollection<ILambdaConnection?> _newConnections = [];
 
   private readonly IShutdownSignal _shutdownSignal;
 
@@ -294,7 +294,7 @@ public class Dispatcher : IDispatcher, IBackgroundDispatcher
   /// sees a completed request that exposes an existing unused / hidden connection
   /// </summary>
   /// <param name="lambdaConnection"></param>
-  public void WakeupBackgroundDispatcher(LambdaConnection? lambdaConnection)
+  public void WakeupBackgroundDispatcher(ILambdaConnection? lambdaConnection)
   {
     // Yes, it is a race condition, but it doesn't matter because the
     // background dispatcher will check it shortly after
@@ -389,7 +389,7 @@ public class Dispatcher : IDispatcher, IBackgroundDispatcher
   /// 
   /// Handles adjusting all counts
   /// </summary>
-  private bool TryGetPendingRequestAndDispatch(LambdaConnection connection)
+  private bool TryGetPendingRequestAndDispatch(ILambdaConnection connection)
   {
     var dispatchedRequest = false;
 
@@ -432,7 +432,7 @@ public class Dispatcher : IDispatcher, IBackgroundDispatcher
   /// Handles adjusting all counts
   /// </summary>
   /// <returns>Whether a request was dispatched</returns>
-  private bool TryBackgroundDispatchOne(PendingRequest pendingRequest, LambdaConnection lambdaConnection)
+  private bool TryBackgroundDispatchOne(PendingRequest pendingRequest, ILambdaConnection lambdaConnection)
   {
     var startedRequest = false;
 

--- a/src/PwrDrvr.LambdaDispatch.Router/EmbeddedMetrics/MetricsLogger.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/EmbeddedMetrics/MetricsLogger.cs
@@ -12,7 +12,7 @@ public class MetricsLogger : IMetricsLogger, IDisposable
 {
   private class Metric
   {
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
     public double Value { get; set; }
     public Unit Unit { get; set; }
   }
@@ -20,7 +20,7 @@ public class MetricsLogger : IMetricsLogger, IDisposable
   private class MetricData
   {
     public Unit Unit { get; set; }
-    public List<double> Values { get; set; } = new List<double>();
+    public List<double> Values { get; set; } = [];
   }
 
   private readonly Channel<Metric> _channel;

--- a/src/PwrDrvr.LambdaDispatch.Router/GetCallbackIP.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/GetCallbackIP.cs
@@ -7,7 +7,7 @@ public interface IGetCallbackIP
 
 public class GetCallbackIP : IGetCallbackIP
 {
-  private readonly string callbackUrl = null;
+  private readonly string callbackUrl;
 
   public string CallbackUrl { get => callbackUrl; }
 

--- a/src/PwrDrvr.LambdaDispatch.Router/ILambdaInstanceQueue.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/ILambdaInstanceQueue.cs
@@ -4,7 +4,7 @@ namespace PwrDrvr.LambdaDispatch.Router;
 
 public interface ILambdaInstanceQueue
 {
-  bool TryGetConnection([NotNullWhen(true)] out LambdaConnection? connection, bool tentative = false);
+  bool TryGetConnection([NotNullWhen(true)] out ILambdaConnection? connection, bool tentative = false);
 
   bool TryRemoveInstance([NotNullWhen(true)] out ILambdaInstance? instance);
 

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaClientConfig.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaClientConfig.cs
@@ -1,14 +1,23 @@
 using Amazon.Lambda;
-using Amazon.Lambda.Model;
 
 namespace PwrDrvr.LambdaDispatch.Router;
 
-public static class LambdaClientConfig
+public interface ILambdaClientConfig
 {
+  IAmazonLambda LambdaClient { get; }
+}
+
+public class LambdaClientConfig : ILambdaClientConfig
+{
+  public IAmazonLambda LambdaClient { get; }
+
+  public LambdaClientConfig()
+  {
+    LambdaClient = new AmazonLambdaClient(CreateConfig());
+  }
+
   private static AmazonLambdaConfig CreateConfig()
   {
-    // Set env var AWS_LAMBDA_SERVICE_URL=http://host.docker.internal:5051
-    // When testing with LambdaTestTool hosted outside of the dev container
     var serviceUrl = System.Environment.GetEnvironmentVariable("AWS_LAMBDA_SERVICE_URL");
     var config = new AmazonLambdaConfig
     {
@@ -23,6 +32,4 @@ public static class LambdaClientConfig
 
     return config;
   }
-
-  public static readonly IAmazonLambda LambdaClient = new AmazonLambdaClient(CreateConfig());
 }

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaConnection.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaConnection.cs
@@ -25,7 +25,51 @@ public enum LambdaConnectionState
   Closed
 }
 
-public class LambdaConnection
+public interface ILambdaConnection
+{
+
+  /// <summary>
+  /// The state of the connection
+  /// </summary>
+  public LambdaConnectionState State { get; }
+
+  /// <summary>
+  /// The Request from the Lambda (which we will send the response on)
+  /// </summary>
+  public HttpRequest Request { get; }
+
+  /// <summary>
+  /// The Response from the Lambda (which we will send the request on)
+  /// </summary>
+  public HttpResponse Response { get; }
+
+  /// <summary>
+  /// Handle back to the Lambda Instance that owns this Connection
+  /// </summary>
+  public ILambdaInstance Instance { get; }
+
+  /// <summary>
+  /// The channel id for this connection
+  /// </summary>
+  public string ChannelId { get; }
+
+  /// <summary>
+  /// Indicates whether this was the first connection for an instance, causing the instance to be marked `Open`
+  /// </summary>
+  public bool FirstConnectionForInstance { get; }
+
+  /// <summary>
+  /// Task that completes when the connection is closed
+  /// </summary>
+  public TaskCompletionSource TCS { get; }
+
+  public Task Discard();
+
+  public Task RunRequest(HttpRequest incomingRequest, HttpResponse incomingResponse);
+
+}
+
+public class LambdaConnection : ILambdaConnection
 {
   private readonly static string _gitHash = Environment.GetEnvironmentVariable("GIT_HASH") ?? "unknown";
   private readonly static string _buildTime = Environment.GetEnvironmentVariable("BUILD_TIME") ?? "unknown";
@@ -34,39 +78,18 @@ public class LambdaConnection
 
   private volatile int _runRequestCalled = 0;
 
-  /// <summary>
-  /// The state of the connection
-  /// </summary>
   public LambdaConnectionState State { get; private set; }
 
-  /// <summary>
-  /// The Request from the Lambda (which we will send the response on)
-  /// </summary>
   public HttpRequest Request { get; private set; }
 
-  /// <summary>
-  /// The Response from the Lambda (which we will send the request on)
-  /// </summary>
   public HttpResponse Response { get; private set; }
 
-  /// <summary>
-  /// Handle back to the Lambda Instance that owns this Connection
-  /// </summary>
   public ILambdaInstance Instance { get; private set; }
 
-  /// <summary>
-  /// The channel id for this connection
-  /// </summary>
   public string ChannelId { get; private set; }
 
-  /// <summary>
-  /// Indicates whether this was the first connection for an instance, causing the instance to be marked `Open`
-  /// </summary>
   public bool FirstConnectionForInstance { get; private set; }
 
-  /// <summary>
-  /// Task that completes when the connection is closed
-  /// </summary>
   public TaskCompletionSource TCS { get; private set; } = new TaskCompletionSource();
 
   private CancellationTokenSource CTS = new CancellationTokenSource();

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstance.cs
@@ -341,6 +341,7 @@ public class LambdaInstance : ILambdaInstance
     IGetCallbackIP getCallbackIP,
     IBackgroundDispatcher dispatcher,
     IMetricsRegistry metricsRegistry,
+    ILambdaClientConfig lambdaClientConfig,
     IAmazonLambda? lambdaClient = null,
     int channelCount = -1)
   {
@@ -361,7 +362,7 @@ public class LambdaInstance : ILambdaInstance
     }
     this.maxConcurrentCount = maxConcurrentCount;
 
-    LambdaClient = lambdaClient ?? LambdaClientConfig.LambdaClient;
+    LambdaClient = lambdaClient ?? lambdaClientConfig.LambdaClient;
   }
 
   /// <summary>

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
@@ -609,6 +609,11 @@ public class LambdaInstanceManager : ILambdaInstanceManager
       _metricsLogger.PutMetric("LambdaInstanceStartingCount", _startingInstanceCount, Unit.Count);
     }
 
+    if (_dispatcher == null)
+    {
+      throw new NullReferenceException("Dispatcher is null");
+    }
+
     // Start a new LambdaInstance and add it to the list
     var instance = new LambdaInstance(maxConcurrentCount: _maxConcurrentCount,
       functionName: _functionName,

--- a/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LambdaInstanceManager.cs
@@ -20,11 +20,11 @@ public interface ILambdaInstanceManager
 {
   void AddBackgroundDispatcherReference(IBackgroundDispatcher dispatcher);
 
-  bool TryGetConnection([NotNullWhen(true)] out LambdaConnection? connection, bool tentative = false);
+  bool TryGetConnection([NotNullWhen(true)] out ILambdaConnection? connection, bool tentative = false);
 
   bool ValidateLambdaId(string lambdaId, [NotNullWhen(true)] out ILambdaInstance? instance);
 
-  void ReenqueueUnusedConnection(LambdaConnection connection, string lambdaId);
+  void ReenqueueUnusedConnection(ILambdaConnection connection, string lambdaId);
 
   Task<AddConnectionResult> AddConnectionForLambda(HttpRequest request, HttpResponse response, string lambdaId, string channelId, AddConnectionDispatchMode dispatchMode);
 
@@ -142,7 +142,7 @@ public class LambdaInstanceManager : ILambdaInstanceManager
     return _instances.TryAdd(instance.Id, instance);
   }
 
-  public bool TryGetConnection([NotNullWhen(true)] out LambdaConnection? connection, bool tentative = false)
+  public bool TryGetConnection([NotNullWhen(true)] out ILambdaConnection? connection, bool tentative = false)
   {
     // Return an available instance or start a new one if none are available
     var gotConnection = _leastOutstandingQueue.TryGetConnection(out var dequeuedConnection, tentative);
@@ -156,7 +156,7 @@ public class LambdaInstanceManager : ILambdaInstanceManager
     return _instances.TryGetValue(lambdaId, out instance);
   }
 
-  public void ReenqueueUnusedConnection(LambdaConnection connection, string lambdaId)
+  public void ReenqueueUnusedConnection(ILambdaConnection connection, string lambdaId)
   {
     // Get the instance for the lambda
     if (_instances.TryGetValue(lambdaId, out var instance))

--- a/src/PwrDrvr.LambdaDispatch.Router/LeastOutstandingQueue.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/LeastOutstandingQueue.cs
@@ -155,7 +155,7 @@ public class LeastOutstandingQueue : IDisposable, ILambdaInstanceQueue
   /// Note: this will perform some limited rebalancing of instances if wrong counts are encountered
   /// </summary>
   /// <returns></returns>
-  public bool TryGetConnection([NotNullWhen(true)] out LambdaConnection? connection, bool tentative = false)
+  public bool TryGetConnection([NotNullWhen(true)] out ILambdaConnection? connection, bool tentative = false)
   {
     connection = null;
 

--- a/src/PwrDrvr.LambdaDispatch.Router/MetadataService.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/MetadataService.cs
@@ -17,7 +17,7 @@ public class MetadataService : IMetadataService
   public string NetworkIP => _networkIP;
   public string? ClusterName => _clusterName;
 
-  public MetadataService(IHttpClientFactory? httpClientFactory = null, IConfig config = null)
+  public MetadataService(IConfig config, IHttpClientFactory? httpClientFactory = null)
   {
     var execEnvType = GetExecEnvType(config);
 

--- a/src/PwrDrvr.LambdaDispatch.Router/MetricsRegistry.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/MetricsRegistry.cs
@@ -18,7 +18,7 @@ public class LoggerMetricsReporter : IReportMetrics
 {
   private readonly ILogger _logger = LoggerInstance.CreateLogger<LoggerMetricsReporter>();
 
-  public IFilterMetrics Filter { get; set; }
+  public IFilterMetrics? Filter { get; set; }
   public TimeSpan FlushInterval { get; set; }
   public IMetricsOutputFormatter Formatter { get; set; }
 

--- a/src/PwrDrvr.LambdaDispatch.Router/MetricsRegistry.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/MetricsRegistry.cs
@@ -12,7 +12,6 @@ using App.Metrics.Histogram;
 using App.Metrics.Meter;
 using App.Metrics.Reporting;
 using App.Metrics.ReservoirSampling.Uniform;
-using App.Metrics.Scheduling;
 using App.Metrics.Timer;
 
 public class LoggerMetricsReporter : IReportMetrics

--- a/src/PwrDrvr.LambdaDispatch.Router/MetricsRegistry.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/MetricsRegistry.cs
@@ -102,56 +102,83 @@ public class CompactMetricsFormatter : IMetricsOutputFormatter
   }
 }
 
-public static class MetricsRegistry
+public interface IMetricsRegistry
 {
-  public static readonly IMetricsRoot Metrics = new MetricsBuilder()
+  IMetricsRoot Metrics { get; }
+  HistogramOptions DispatchDelay { get; }
+  HistogramOptions LambdaOpenDelay { get; }
+  CounterOptions RequestCount { get; }
+  HistogramOptions IncomingRequestDuration { get; }
+  HistogramOptions IncomingRequestDurationAfterDispatch { get; }
+  TimerOptions LambdaRequestTimer { get; }
+  CounterOptions ImmediateDispatchCount { get; }
+  CounterOptions QueuedRequests { get; }
+  CounterOptions RunningRequests { get; }
+  CounterOptions PendingDispatchCount { get; }
+  CounterOptions PendingDispatchForegroundCount { get; }
+  CounterOptions PendingDispatchBackgroundCount { get; }
+  CounterOptions LambdaInvokeCount { get; }
+  GaugeOptions LambdaInstanceStartingCount { get; }
+  GaugeOptions IncomingRequestRPS { get; }
+  GaugeOptions IncomingRequestDurationEWMA { get; }
+  GaugeOptions LambdaInstanceStoppingCount { get; }
+  GaugeOptions LambdaInstanceRunningCount { get; }
+  GaugeOptions LambdaInstanceDesiredCount { get; }
+  CounterOptions LambdaConnectionRejectedCount { get; }
+  HistogramOptions LambdaInstanceOpenConnections { get; }
+  HistogramOptions LambdaInstanceRunningRequests { get; }
+  MeterOptions IncomingRequestsMeter { get; }
+  void Reset();
+  Task PrintMetrics();
+}
+
+
+public class MetricsRegistry : IMetricsRegistry
+{
+  public IMetricsRoot Metrics { get; } = new MetricsBuilder()
     .Report.Using<LoggerMetricsReporter>()
     .Build();
 
-  static MetricsRegistry()
-  {
-  }
-
-  public static void Reset()
+  public void Reset()
   {
     Metrics.Manage.Reset();
   }
 
-  public static readonly HistogramOptions DispatchDelay = new()
+  public HistogramOptions DispatchDelay { get; } = new()
   {
     Name = "DispatchDelay",
     MeasurementUnit = Unit.Custom("ms"),
     Reservoir = () => new DefaultAlgorithmRReservoir(),
   };
 
-  public static readonly HistogramOptions LambdaOpenDelay = new()
+  public HistogramOptions LambdaOpenDelay { get; } = new()
   {
     Name = "LambdaOpenDelay",
     MeasurementUnit = Unit.Custom("ms"),
     Reservoir = () => new DefaultAlgorithmRReservoir(),
   };
 
-  public static readonly CounterOptions RequestCount = new()
+  public CounterOptions RequestCount { get; } = new()
   {
     Name = "RequestCount",
     MeasurementUnit = Unit.Requests
   };
 
-  public static readonly HistogramOptions IncomingRequestDuration = new()
+  public HistogramOptions IncomingRequestDuration { get; } = new()
   {
     Name = "IncomingRequestDuration",
     MeasurementUnit = Unit.Custom("ms"),
     Reservoir = () => new DefaultAlgorithmRReservoir(),
   };
 
-  public static readonly HistogramOptions IncomingRequestDurationAfterDispatch = new()
+  public HistogramOptions IncomingRequestDurationAfterDispatch { get; } = new()
   {
     Name = "IncomingRequestDurationAfterDispatch",
     MeasurementUnit = Unit.Custom("ms"),
     Reservoir = () => new DefaultAlgorithmRReservoir(),
   };
 
-  public static readonly TimerOptions LambdaRequestTimer = new()
+  public TimerOptions LambdaRequestTimer { get; } = new()
   {
     Name = "LambdaRequestTimer",
     MeasurementUnit = Unit.Custom("ms"),
@@ -159,37 +186,37 @@ public static class MetricsRegistry
     RateUnit = TimeUnit.Milliseconds,
   };
 
-  public static readonly CounterOptions ImmediateDispatchCount = new()
+  public CounterOptions ImmediateDispatchCount { get; } = new()
   {
     Name = "ImmediateDispatchCount",
     MeasurementUnit = Unit.Requests
   };
 
-  public static readonly CounterOptions QueuedRequests = new()
+  public CounterOptions QueuedRequests { get; } = new()
   {
     Name = "QueuedRequests",
     MeasurementUnit = Unit.Requests
   };
 
-  public static readonly CounterOptions RunningRequests = new()
+  public CounterOptions RunningRequests { get; } = new()
   {
     Name = "RunningRequests",
     MeasurementUnit = Unit.Requests
   };
 
-  public static readonly CounterOptions PendingDispatchCount = new()
+  public CounterOptions PendingDispatchCount { get; } = new()
   {
     Name = "PendingDispatchCount",
     MeasurementUnit = Unit.Requests
   };
 
-  public static readonly CounterOptions PendingDispatchForegroundCount = new()
+  public CounterOptions PendingDispatchForegroundCount { get; } = new()
   {
     Name = "PendingDispatchForegroundCount",
     MeasurementUnit = Unit.Requests
   };
 
-  public static readonly CounterOptions PendingDispatchBackgroundCount = new()
+  public CounterOptions PendingDispatchBackgroundCount { get; } = new()
   {
     Name = "PendingDispatchBackgroundCount",
     MeasurementUnit = Unit.Requests
@@ -198,81 +225,148 @@ public static class MetricsRegistry
   /// <summary>
   /// Number of Lambda.InvokeAsync calls outstanding
   /// </summary>
-  public static readonly CounterOptions LambdaInvokeCount = new()
+  public CounterOptions LambdaInvokeCount { get; } = new()
   {
     Name = "LambdaInvokeCount",
     MeasurementUnit = Unit.Items,
   };
 
-  public static readonly GaugeOptions LambdaInstanceStartingCount = new()
+  public GaugeOptions LambdaInstanceStartingCount { get; } = new()
   {
     Name = "LambdaInstanceStartingCount",
     MeasurementUnit = Unit.Items,
   };
 
-  public static readonly GaugeOptions IncomingRequestRPS = new()
+  public GaugeOptions IncomingRequestRPS { get; } = new()
   {
     Name = "IncomingRequestRPS",
     MeasurementUnit = Unit.Requests,
   };
 
-  public static readonly GaugeOptions IncomingRequestDurationEWMA = new()
+  public GaugeOptions IncomingRequestDurationEWMA { get; } = new()
   {
     Name = "IncomingRequestDurationEWMA",
     MeasurementUnit = Unit.Custom("ms"),
   };
 
-  public static readonly GaugeOptions LambdaInstanceStoppingCount = new()
+  public GaugeOptions LambdaInstanceStoppingCount { get; } = new()
   {
     Name = "LambdaInstanceStoppingCount",
     MeasurementUnit = Unit.Items,
   };
 
-  public static readonly GaugeOptions LambdaInstanceRunningCount = new()
+  public GaugeOptions LambdaInstanceRunningCount { get; } = new()
   {
     Name = "LambdaInstanceRunningCount",
     MeasurementUnit = Unit.Items,
   };
 
-  public static readonly GaugeOptions LambdaInstanceDesiredCount = new()
+  public GaugeOptions LambdaInstanceDesiredCount { get; } = new()
   {
     Name = "LambdaInstanceDesiredCount",
     MeasurementUnit = Unit.Items,
   };
 
-  public static readonly CounterOptions LambdaConnectionRejectedCount = new()
+  public CounterOptions LambdaConnectionRejectedCount { get; } = new()
   {
     Name = "LambdaConnectionRejectedCount",
     MeasurementUnit = Unit.Connections,
   };
 
-  public static readonly HistogramOptions LambdaInstanceOpenConnections = new()
+  public HistogramOptions LambdaInstanceOpenConnections { get; } = new()
   {
     Name = "LambdaInstanceOpenConnections",
     MeasurementUnit = Unit.Requests,
     Reservoir = () => new DefaultAlgorithmRReservoir(),
   };
 
-  public static readonly HistogramOptions LambdaInstanceRunningRequests = new()
+  public HistogramOptions LambdaInstanceRunningRequests { get; } = new()
   {
     Name = "LambdaInstanceRunningRequests",
     MeasurementUnit = Unit.Requests,
     Reservoir = () => new DefaultAlgorithmRReservoir(),
   };
 
-  public static readonly MeterOptions IncomingRequestsMeter = new()
+  public MeterOptions IncomingRequestsMeter { get; } = new()
   {
     Name = "IncomingRequests",
     MeasurementUnit = Unit.Requests,
     RateUnit = TimeUnit.Seconds,
   };
 
-  public static async Task PrintMetrics()
+  public async Task PrintMetrics()
   {
     while (true)
     {
-      await Task.WhenAll(MetricsRegistry.Metrics.ReportRunner.RunAllAsync()).ConfigureAwait(false);
+      await Task.WhenAll(this.Metrics.ReportRunner.RunAllAsync()).ConfigureAwait(false);
       await Task.Delay(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
     }
+  }
+}
+
+
+public static class MetricsRegistrySingleton
+{
+  private static IMetricsRegistry _instance = new MetricsRegistry();
+
+  public static IMetricsRoot Metrics => _instance.Metrics;
+
+  public static void Reset()
+  {
+    Metrics.Manage.Reset();
+  }
+
+  public static HistogramOptions DispatchDelay => _instance.DispatchDelay;
+
+  public static HistogramOptions LambdaOpenDelay => _instance.LambdaOpenDelay;
+
+  public static CounterOptions RequestCount => _instance.RequestCount;
+
+  public static HistogramOptions IncomingRequestDuration => _instance.IncomingRequestDuration;
+
+  public static HistogramOptions IncomingRequestDurationAfterDispatch => _instance.IncomingRequestDurationAfterDispatch;
+
+  public static TimerOptions LambdaRequestTimer => _instance.LambdaRequestTimer;
+
+  public static CounterOptions ImmediateDispatchCount => _instance.ImmediateDispatchCount;
+
+  public static CounterOptions QueuedRequests => _instance.QueuedRequests;
+
+  public static CounterOptions RunningRequests => _instance.RunningRequests;
+
+  public static CounterOptions PendingDispatchCount => _instance.PendingDispatchCount;
+
+  public static CounterOptions PendingDispatchForegroundCount => _instance.PendingDispatchForegroundCount;
+
+  public static CounterOptions PendingDispatchBackgroundCount => _instance.PendingDispatchBackgroundCount;
+
+  /// <summary>
+  /// Number of Lambda.InvokeAsync calls outstanding
+  /// </summary>
+  public static CounterOptions LambdaInvokeCount => _instance.LambdaInvokeCount;
+
+  public static GaugeOptions LambdaInstanceStartingCount => _instance.LambdaInstanceStartingCount;
+
+  public static GaugeOptions IncomingRequestRPS => _instance.IncomingRequestRPS;
+
+  public static GaugeOptions IncomingRequestDurationEWMA => _instance.IncomingRequestDurationEWMA;
+
+  public static GaugeOptions LambdaInstanceStoppingCount => _instance.LambdaInstanceStoppingCount;
+
+  public static GaugeOptions LambdaInstanceRunningCount => _instance.LambdaInstanceRunningCount;
+
+  public static GaugeOptions LambdaInstanceDesiredCount => _instance.LambdaInstanceDesiredCount;
+
+  public static CounterOptions LambdaConnectionRejectedCount => _instance.LambdaConnectionRejectedCount;
+
+  public static HistogramOptions LambdaInstanceOpenConnections => _instance.LambdaInstanceOpenConnections;
+
+  public static HistogramOptions LambdaInstanceRunningRequests => _instance.LambdaInstanceRunningRequests;
+
+  public static MeterOptions IncomingRequestsMeter => _instance.IncomingRequestsMeter;
+
+  public static async Task PrintMetrics()
+  {
+    await _instance.PrintMetrics();
   }
 }

--- a/src/PwrDrvr.LambdaDispatch.Router/PoolOptions.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/PoolOptions.cs
@@ -20,7 +20,7 @@ public class PoolOptions : IPoolOptions
 {
   public void Setup(string lambdaName, string poolId)
   {
-    if (LambdaName != null || PoolId != null)
+    if (!string.IsNullOrEmpty(LambdaName) || !string.IsNullOrEmpty(PoolId))
     {
       throw new InvalidOperationException("PoolOptions has already been setup");
     }
@@ -29,7 +29,7 @@ public class PoolOptions : IPoolOptions
     PoolId = poolId;
   }
 
-  public string LambdaName { get; private set; }
+  public string LambdaName { get; private set; } = string.Empty;
 
-  public string PoolId { get; private set; }
+  public string PoolId { get; private set; } = string.Empty;
 }

--- a/src/PwrDrvr.LambdaDispatch.Router/RoundRobinLambdaInstanceQueue.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/RoundRobinLambdaInstanceQueue.cs
@@ -12,7 +12,7 @@ public class RoundRobinLambdaInstanceQueue() : ILambdaInstanceQueue
     _queue.Enqueue(instance);
   }
 
-  public bool TryGetConnection([NotNullWhen(true)] out LambdaConnection? connection, bool tentative = false)
+  public bool TryGetConnection([NotNullWhen(true)] out ILambdaConnection? connection, bool tentative = false)
   {
     connection = null;
 

--- a/src/PwrDrvr.LambdaDispatch.Router/RoundRobinLambdaInstanceQueue2.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/RoundRobinLambdaInstanceQueue2.cs
@@ -29,7 +29,7 @@ public class RoundRobinLambdaInstanceQueue2() : ILambdaInstanceQueue
     }
   }
 
-  public bool TryGetConnection([NotNullWhen(true)] out LambdaConnection? connection, bool tentative = false)
+  public bool TryGetConnection([NotNullWhen(true)] out ILambdaConnection? connection, bool tentative = false)
   {
     connection = null;
 

--- a/src/PwrDrvr.LambdaDispatch.Router/Startup.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Startup.cs
@@ -39,6 +39,7 @@ public class Startup
         // services.AddSingleton<ILambdaInstanceQueue, RoundRobinLambdaInstanceQueue2>();
         var metricsRegistry = new MetricsRegistry();
         services.AddSingleton<IMetricsRegistry>(metricsRegistry);
+        services.AddSingleton<ILambdaClientConfig, LambdaClientConfig>();
         services.AddScoped<IPoolOptions, PoolOptions>();
         services.AddScoped<ILambdaInstanceQueue, LeastOutstandingQueue>();
         services.AddScoped<ILambdaInstanceManager, LambdaInstanceManager>();

--- a/src/PwrDrvr.LambdaDispatch.Router/Startup.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/Startup.cs
@@ -37,6 +37,8 @@ public class Startup
 
         // services.AddSingleton<ILambdaInstanceQueue, RoundRobinLambdaInstanceQueue>();
         // services.AddSingleton<ILambdaInstanceQueue, RoundRobinLambdaInstanceQueue2>();
+        var metricsRegistry = new MetricsRegistry();
+        services.AddSingleton<IMetricsRegistry>(metricsRegistry);
         services.AddScoped<IPoolOptions, PoolOptions>();
         services.AddScoped<ILambdaInstanceQueue, LeastOutstandingQueue>();
         services.AddScoped<ILambdaInstanceManager, LambdaInstanceManager>();
@@ -44,7 +46,7 @@ public class Startup
         services.AddSingleton<IPoolManager, PoolManager>();
         services.AddSingleton<IShutdownSignal>(_shutdownSignal);
 
-        Task.Run(MetricsRegistry.PrintMetrics).ConfigureAwait(false);
+        Task.Run(metricsRegistry.PrintMetrics).ConfigureAwait(false);
     }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IConfig config, IHostApplicationLifetime applicationLifetime)

--- a/src/PwrDrvr.LambdaDispatch.Router/TrailingAverage.cs
+++ b/src/PwrDrvr.LambdaDispatch.Router/TrailingAverage.cs
@@ -1,6 +1,6 @@
 public class TrailingAverage
 {
-  private readonly List<(DateTime timestamp, double sum, int count)> _data = new List<(DateTime, double, int)>();
+  private readonly List<(DateTime timestamp, double sum, int count)> _data = [];
   private double _totalSum = 0;
   private int _totalCount = 0;
 

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
@@ -117,7 +117,7 @@ public class ChunkedControllerTests
     var mockPool = new Mock<IPool>();
     var mockDispatcher = new Mock<IDispatcher>();
     mockPool.Setup(p => p.Dispatcher).Returns(mockDispatcher.Object);
-    IPool outPool = mockPool.Object;
+    IPool? outPool = mockPool.Object;
     mockPoolManager.Setup(p => p.GetPoolByPoolId("default", out outPool)).Returns(true);
 
     var httpContext = new DefaultHttpContext();

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
@@ -1,5 +1,4 @@
 using Moq;
-using NUnit.Framework;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
@@ -10,8 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http.Features;
 using System.Security.Claims;
 
-namespace PwrDrvr.LambdaDispatch.Router.Tests;
-
+namespace PwrDrvr.LambdaDispatch.Router.ControlChannels.Tests;
 
 public class ThrowingHttpContext : HttpContext
 {

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using PwrDrvr.LambdaDispatch.Router.ControlChannels.Controllers;
 using PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
+using PwrDrvr.LambdaDispatch.Router.Tests.Mocks;
 
 namespace PwrDrvr.LambdaDispatch.Router.Tests;
 
@@ -14,6 +15,7 @@ public class ChunkedControllerTests
   private Mock<IPoolManager> mockPoolManager;
   private Mock<IMetricsLogger> mockMetricsLogger;
   private Mock<ILogger<ChunkedController>> mockLogger;
+  private Mock<IMetricsRegistry> mockMetricsRegistry;
   private ChunkedController controller;
 
   [SetUp]
@@ -22,7 +24,8 @@ public class ChunkedControllerTests
     mockPoolManager = new Mock<IPoolManager>();
     mockMetricsLogger = new Mock<IMetricsLogger>();
     mockLogger = new Mock<ILogger<ChunkedController>>();
-    controller = new ChunkedController(mockPoolManager.Object, mockMetricsLogger.Object, mockLogger.Object);
+    mockMetricsRegistry = MetricsRegistryMockFactory.Create();
+    controller = new ChunkedController(mockPoolManager.Object, mockMetricsLogger.Object, mockLogger.Object, mockMetricsRegistry.Object);
   }
 
   [Test]

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
@@ -143,7 +143,7 @@ public class ChunkedControllerTests
     var mockPool = new Mock<IPool>();
     var mockDispatcher = new Mock<IDispatcher>();
     mockPool.Setup(p => p.Dispatcher).Returns(mockDispatcher.Object);
-    IPool outPool = mockPool.Object;
+    IPool? outPool = mockPool.Object;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(true);
 
     // Act
@@ -159,7 +159,7 @@ public class ChunkedControllerTests
     // Arrange
     var poolId = "testPoolId";
     var lambdaId = "testLambdaId";
-    IPool outPool = null;
+    IPool? outPool = null;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(false);
 
     // Act
@@ -177,7 +177,7 @@ public class ChunkedControllerTests
     var lambdaId = "testLambda";
     var mockPool = new Mock<IPool>();
     var mockDispatcher = new Mock<IDispatcher>();
-    IPool outPool = mockPool.Object;
+    IPool? outPool = mockPool.Object;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(true);
     mockPool.Setup(x => x.Dispatcher).Returns(mockDispatcher.Object);
     mockPool.Setup(x => x.Dispatcher.CloseInstance(lambdaId, true)).Returns(Task.CompletedTask);
@@ -196,7 +196,7 @@ public class ChunkedControllerTests
     // Arrange
     var poolId = "testPool";
     var lambdaId = "testLambda";
-    mockPoolManager.Setup(x => x.GetPoolByPoolId(poolId, out It.Ref<IPool>.IsAny)).Returns(false);
+    mockPoolManager.Setup(x => x.GetPoolByPoolId(poolId, out It.Ref<IPool?>.IsAny)).Returns(false);
 
     // Act
     var result = await controller.CloseInstance(poolId, lambdaId);
@@ -214,7 +214,7 @@ public class ChunkedControllerTests
     var mockPool = new Mock<IPool>();
     var mockDispatcher = new Mock<IDispatcher>();
     mockDispatcher.Setup(x => x.CloseInstance(lambdaId, true)).Returns(Task.CompletedTask);
-    IPool outPool = mockPool.Object;
+    IPool? outPool = mockPool.Object;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(true);
     mockPool.Setup(x => x.Dispatcher).Returns(mockDispatcher.Object);
 
@@ -253,7 +253,7 @@ public class ChunkedControllerTests
     var mockDispatcher = new Mock<IDispatcher>();
     mockDispatcher.Setup(x => x.AddConnectionForLambda(It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>(), lambdaId, channelId))
                   .Returns(Task.FromResult(dispatcherResult));
-    IPool outPool = mockPool.Object;
+    IPool? outPool = mockPool.Object;
     mockPoolManager.Setup(p => p.GetPoolByPoolId("default", out outPool)).Returns(true);
     mockPool.Setup(x => x.Dispatcher).Returns(mockDispatcher.Object);
     var httpContext = new DefaultHttpContext();
@@ -290,7 +290,7 @@ public class ChunkedControllerTests
     var mockDispatcher = new Mock<IDispatcher>();
     mockDispatcher.Setup(x => x.AddConnectionForLambda(It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>(), lambdaId, channelId))
                   .Returns(Task.FromResult(dispatcherResult));
-    IPool outPool = mockPool.Object;
+    IPool? outPool = mockPool.Object;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(true);
     mockPool.Setup(x => x.Dispatcher).Returns(mockDispatcher.Object);
     var httpContext = new DefaultHttpContext();
@@ -328,7 +328,7 @@ public class ChunkedControllerTests
     var mockDispatcher = new Mock<IDispatcher>();
     mockDispatcher.Setup(x => x.AddConnectionForLambda(It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>(), lambdaId, channelId))
                   .Returns(Task.FromResult(dispatcherResult));
-    IPool outPool = mockPool.Object;
+    IPool? outPool = mockPool.Object;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(true);
     mockPool.Setup(x => x.Dispatcher).Returns(mockDispatcher.Object);
     var httpContext = new DefaultHttpContext();
@@ -347,7 +347,7 @@ public class ChunkedControllerTests
   }
 
   [Test]
-  public async Task Post_LambdaIdNotFoundThrows_DoesNotThrow()
+  public void Post_LambdaIdNotFoundThrows_DoesNotThrow()
   {
     // Arrange
     var poolId = "testPool";
@@ -366,7 +366,7 @@ public class ChunkedControllerTests
     var mockDispatcher = new Mock<IDispatcher>();
     mockDispatcher.Setup(x => x.AddConnectionForLambda(It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>(), lambdaId, channelId))
                   .Returns(Task.FromResult(dispatcherResult));
-    IPool outPool = mockPool.Object;
+    IPool? outPool = mockPool.Object;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(true);
     mockPool.Setup(x => x.Dispatcher).Returns(mockDispatcher.Object);
     var httpContext = new ThrowingHttpContext();
@@ -389,7 +389,7 @@ public class ChunkedControllerTests
     var poolId = "testPool";
     var lambdaId = "testLambda";
     var channelId = "testChannel";
-    IPool outPool = null;
+    IPool? outPool = null;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(false);
     var httpContext = new DefaultHttpContext();
     httpContext.Request.Headers["X-Lambda-Id"] = lambdaId;
@@ -414,7 +414,7 @@ public class ChunkedControllerTests
     var poolId = string.Empty;
     var lambdaId = "testLambda";
     var channelId = "testChannel";
-    IPool outPool = null;
+    IPool? outPool = null;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(false);
     var httpContext = new DefaultHttpContext();
     httpContext.Request.Headers["X-Lambda-Id"] = lambdaId;
@@ -439,7 +439,7 @@ public class ChunkedControllerTests
     var poolId = "testPool";
     var lambdaId = "testLambda";
     var channelId = "testChannel";
-    IPool outPool = null;
+    IPool? outPool = null;
     mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(false);
     var httpContext = new DefaultHttpContext();
     httpContext.Request.Headers["X-Pool-Id"] = poolId;

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
@@ -288,6 +288,31 @@ public class ChunkedControllerTests
   }
 
   [Test]
+  public async Task Post_PoolIdMultiNotFound_ReturnsConflict()
+  {
+    // Arrange
+    var poolId = string.Empty;
+    var lambdaId = "testLambda";
+    var channelId = "testChannel";
+    IPool outPool = null;
+    mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(false);
+    var httpContext = new DefaultHttpContext();
+    httpContext.Request.Headers["X-Lambda-Id"] = lambdaId;
+    httpContext.Request.Headers["X-Pool-Id"] = poolId;
+    httpContext.Request.Headers["Date"] = "Tue, 01 Feb 2022 12:34:56 GMT";
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = httpContext
+    };
+
+    // Act
+    await controller.Post(lambdaId, channelId);
+
+    // Assert
+    Assert.AreEqual(409, controller.Response.StatusCode);
+  }
+
+  [Test]
   public async Task Post_NoXLambdaIdHeader_ReturnsBadRequest()
   {
     // Arrange

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ChunkedControllerTests.cs
@@ -2,6 +2,7 @@ using Moq;
 using NUnit.Framework;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using PwrDrvr.LambdaDispatch.Router.ControlChannels.Controllers;
 using PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
 
@@ -57,5 +58,70 @@ public class ChunkedControllerTests
 
     // Assert
     Assert.That(result, Is.InstanceOf<NotFoundResult>());
+  }
+
+  [Test]
+  public async Task CloseInstance_WhenPoolExists_ClosesInstanceAndReturnsOk()
+  {
+    // Arrange
+    var poolId = "testPool";
+    var lambdaId = "testLambda";
+    var mockPool = new Mock<IPool>();
+    var mockDispatcher = new Mock<IDispatcher>();
+    IPool outPool = mockPool.Object;
+    mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(true);
+    mockPool.Setup(x => x.Dispatcher).Returns(mockDispatcher.Object);
+    mockPool.Setup(x => x.Dispatcher.CloseInstance(lambdaId, true)).Returns(Task.CompletedTask);
+
+    // Act
+    var result = await controller.CloseInstance(poolId, lambdaId);
+
+    // Assert
+    Assert.IsInstanceOf<OkResult>(result);
+    mockPool.Verify(x => x.Dispatcher.CloseInstance(lambdaId, true), Times.Once);
+  }
+
+  [Test]
+  public async Task CloseInstance_WhenPoolDoesNotExist_ReturnsNotFound()
+  {
+    // Arrange
+    var poolId = "testPool";
+    var lambdaId = "testLambda";
+    mockPoolManager.Setup(x => x.GetPoolByPoolId(poolId, out It.Ref<IPool>.IsAny)).Returns(false);
+
+    // Act
+    var result = await controller.CloseInstance(poolId, lambdaId);
+
+    // Assert
+    Assert.IsInstanceOf<NotFoundResult>(result);
+  }
+
+  [Test]
+  public async Task CloseInstance_WithoutPoolId_UsesGetPoolIdAndClosesInstance()
+  {
+    // Arrange
+    var poolId = "testPool";
+    var lambdaId = "testLambda";
+    var mockPool = new Mock<IPool>();
+    var mockDispatcher = new Mock<IDispatcher>();
+    mockDispatcher.Setup(x => x.CloseInstance(lambdaId, true)).Returns(Task.CompletedTask);
+    IPool outPool = mockPool.Object;
+    mockPoolManager.Setup(p => p.GetPoolByPoolId(poolId, out outPool)).Returns(true);
+    mockPool.Setup(x => x.Dispatcher).Returns(mockDispatcher.Object);
+
+    var httpContext = new DefaultHttpContext();
+    httpContext.Request.Headers["X-Pool-Id"] = poolId;
+
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = httpContext
+    };
+
+    // Act
+    var result = await controller.CloseInstance(lambdaId);
+
+    // Assert
+    Assert.IsInstanceOf<OkResult>(result);
+    mockPool.Verify(x => x.Dispatcher.CloseInstance(lambdaId, true), Times.Once);
   }
 }

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/DefaultControllerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/DefaultControllerTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using PwrDrvr.LambdaDispatch.Router.ControlChannels.Controllers;
+
+namespace PwrDrvr.LambdaDispatch.Router.ControlChannels.Tests;
+
+public class DefaultControllerTests
+{
+  private DefaultController _controller;
+  private DefaultHttpContext _httpContext;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _httpContext = new DefaultHttpContext();
+    _httpContext.Response.Body = new MemoryStream();
+
+    _controller = new DefaultController
+    {
+      ControllerContext = new ControllerContext
+      {
+        HttpContext = _httpContext
+      }
+    };
+  }
+
+  [Test]
+  public async Task HandleRequest_SetsStatusCodeTo404()
+  {
+    await _controller.HandleRequest();
+
+    Assert.That(_httpContext.Response.StatusCode, Is.EqualTo(404));
+  }
+
+  [Test]
+  public async Task HandleRequest_WritesErrorMessageToResponse()
+  {
+    await _controller.HandleRequest();
+
+    _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+    var responseBody = await new StreamReader(_httpContext.Response.Body).ReadToEndAsync();
+
+    Assert.That(responseBody, Is.EqualTo("No matching Control Channel route found"));
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ResetControllerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Areas/ControlChannels/Controllers/ResetControllerTests.cs
@@ -1,0 +1,26 @@
+using Moq;
+using PwrDrvr.LambdaDispatch.Router.ControlChannels.Controllers;
+using PwrDrvr.LambdaDispatch.Router.Tests.Mocks;
+
+namespace PwrDrvr.LambdaDispatch.Router.ControlChannels.Tests;
+
+public class ResetControllerTests
+{
+  private ResetController _controller;
+  private Mock<IMetricsRegistry> _mockMetricsRegistry;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _mockMetricsRegistry = MetricsRegistryMockFactory.Create();
+    _controller = new ResetController(_mockMetricsRegistry.Object);
+  }
+
+  [Test]
+  public void HandleRequest_CallsResetOnMetricsRegistry()
+  {
+    _controller.HandleRequest();
+
+    _mockMetricsRegistry.Verify(m => m.Reset(), Times.Once);
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/ConfigTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/ConfigTests.cs
@@ -8,7 +8,7 @@ public class ConfigTests
   [Test]
   public void TestCreateAndValidate_ValidFunctionName()
   {
-    var inMemorySettings = new Dictionary<string, string> {
+    var inMemorySettings = new Dictionary<string, string?> {
         {"FunctionName", "my-function"},
     };
     IConfiguration configuration = new ConfigurationBuilder()
@@ -26,7 +26,7 @@ public class ConfigTests
   [Test]
   public void TestCreateAndValidate_ValidFunctionNameWithQualifier()
   {
-    var inMemorySettings = new Dictionary<string, string> {
+    var inMemorySettings = new Dictionary<string, string?> {
         {"FunctionName", "my-function:qualifier"},
     };
     IConfiguration configuration = new ConfigurationBuilder()
@@ -44,7 +44,7 @@ public class ConfigTests
   [Test]
   public void TestCreateAndValidate_ValidLambdaArn()
   {
-    var inMemorySettings = new Dictionary<string, string> {
+    var inMemorySettings = new Dictionary<string, string?> {
         {"FunctionName", "arn:aws:lambda:us-west-2:123456789012:function:my-function"},
     };
     IConfiguration configuration = new ConfigurationBuilder()
@@ -62,7 +62,7 @@ public class ConfigTests
   [Test]
   public void TestCreateAndValidate_ValidLambdaArnWithQualifier()
   {
-    var inMemorySettings = new Dictionary<string, string> {
+    var inMemorySettings = new Dictionary<string, string?> {
         {"FunctionName", "arn:aws:lambda:us-west-2:123456789012:function:my-function:qualifier"},
     };
     IConfiguration configuration = new ConfigurationBuilder()
@@ -80,7 +80,7 @@ public class ConfigTests
   [Test]
   public void TestCreateAndValidate_InvalidFunctionName_ThrowsException()
   {
-    var inMemorySettings = new Dictionary<string, string> {
+    var inMemorySettings = new Dictionary<string, string?> {
         {"FunctionName", "invalid function name"},
     };
     IConfiguration configuration = new ConfigurationBuilder()
@@ -109,7 +109,7 @@ public class ConfigTests
   [TestCase("EnvVarForCallbackIp", "@", typeof(ApplicationException))]
   public void TestCreateAndValidate_InvalidSettings(string settingKey, string settingValue, Type expectedExceptionType)
   {
-    var inMemorySettings = new Dictionary<string, string> {
+    var inMemorySettings = new Dictionary<string, string?> {
         { "FunctionName", "my-function"},
         {settingKey, settingValue},
     };
@@ -123,7 +123,7 @@ public class ConfigTests
   [Test]
   public void TestCreateAndValidate_InvalidSettings_AllowInsecureControlChannelFalse()
   {
-    var inMemorySettings = new Dictionary<string, string> {
+    var inMemorySettings = new Dictionary<string, string?> {
         { "FunctionName", "my-function"},
         { "AllowInsecureControlChannel", "false"},
         { "PreferredControlChannelScheme", "http" },
@@ -138,7 +138,7 @@ public class ConfigTests
   [Test]
   public void TestCreateAndValidate_AllowInsecureControlChannelTrue()
   {
-    var inMemorySettings = new Dictionary<string, string> {
+    var inMemorySettings = new Dictionary<string, string?> {
         { "FunctionName", "my-function"},
         { "AllowInsecureControlChannel", "true"},
         { "PreferredControlChannelScheme", "http" },

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherSimpleTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherSimpleTests.cs
@@ -35,7 +35,7 @@ public class DispatcherSimpleTests
   public void PingInstance_ValidInstanceId_ReturnsTrue()
   {
     string instanceId = "valid-instance-id";
-    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out It.Ref<ILambdaInstance>.IsAny)).Returns(true);
+    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out It.Ref<ILambdaInstance?>.IsAny)).Returns(true);
 
     bool result = _dispatcher.PingInstance(instanceId);
 
@@ -46,7 +46,7 @@ public class DispatcherSimpleTests
   public void PingInstance_InvalidInstanceId_ReturnsFalse()
   {
     string instanceId = "invalid-instance-id";
-    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out It.Ref<ILambdaInstance>.IsAny)).Returns(false);
+    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out It.Ref<ILambdaInstance?>.IsAny)).Returns(false);
 
     bool result = _dispatcher.PingInstance(instanceId);
 
@@ -70,7 +70,7 @@ public class DispatcherSimpleTests
   public async Task CloseInstance_InvalidInstanceId_DoesNotCallCloseInstance()
   {
     string instanceId = "invalid-instance-id";
-    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out It.Ref<ILambdaInstance>.IsAny)).Returns(false);
+    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out It.Ref<ILambdaInstance?>.IsAny)).Returns(false);
 
     await _dispatcher.CloseInstance(instanceId);
 

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherSimpleTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherSimpleTests.cs
@@ -1,0 +1,79 @@
+using NUnit.Framework;
+using Moq;
+using Microsoft.Extensions.Logging;
+using PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
+using PwrDrvr.LambdaDispatch.Router.Tests.Mocks;
+
+namespace PwrDrvr.LambdaDispatch.Router.Tests;
+
+[TestFixture]
+public class DispatcherSimpleTests
+{
+  private Dispatcher _dispatcher;
+  private Mock<ILogger<Dispatcher>> _mockLogger;
+  private Mock<IMetricsLogger> _mockMetricsLogger;
+  private Mock<ILambdaInstanceManager> _mockLambdaInstanceManager;
+  private Mock<IShutdownSignal> _mockShutdownSignal;
+  private Mock<IMetricsRegistry> _metricsRegistry;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _mockLambdaInstanceManager = new Mock<ILambdaInstanceManager>();
+    _mockLogger = new Mock<ILogger<Dispatcher>>();
+    _mockMetricsLogger = new Mock<IMetricsLogger>();
+    _mockShutdownSignal = new Mock<IShutdownSignal>();
+    _metricsRegistry = MetricsRegistryMockFactory.Create();
+    _dispatcher = new Dispatcher(_mockLogger.Object,
+          _mockMetricsLogger.Object,
+          _mockLambdaInstanceManager.Object,
+          _mockShutdownSignal.Object,
+          metricsRegistry: _metricsRegistry.Object);
+  }
+
+  [Test]
+  public void PingInstance_ValidInstanceId_ReturnsTrue()
+  {
+    string instanceId = "valid-instance-id";
+    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out It.Ref<ILambdaInstance>.IsAny)).Returns(true);
+
+    bool result = _dispatcher.PingInstance(instanceId);
+
+    Assert.That(result, Is.True);
+  }
+
+  [Test]
+  public void PingInstance_InvalidInstanceId_ReturnsFalse()
+  {
+    string instanceId = "invalid-instance-id";
+    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out It.Ref<ILambdaInstance>.IsAny)).Returns(false);
+
+    bool result = _dispatcher.PingInstance(instanceId);
+
+    Assert.That(result, Is.False);
+  }
+
+  [Test]
+  public async Task CloseInstance_ValidInstanceId_CallsCloseInstance()
+  {
+    string instanceId = "valid-instance-id";
+    var lambdaInstance = new Mock<ILambdaInstance>();
+    var lambdaInstanceOut = lambdaInstance.Object;
+    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out lambdaInstanceOut)).Returns(true);
+
+    await _dispatcher.CloseInstance(instanceId);
+
+    _mockLambdaInstanceManager.Verify(l => l.CloseInstance(lambdaInstanceOut, false), Times.Once);
+  }
+
+  [Test]
+  public async Task CloseInstance_InvalidInstanceId_DoesNotCallCloseInstance()
+  {
+    string instanceId = "invalid-instance-id";
+    _mockLambdaInstanceManager.Setup(l => l.ValidateLambdaId(instanceId, out It.Ref<ILambdaInstance>.IsAny)).Returns(false);
+
+    await _dispatcher.CloseInstance(instanceId);
+
+    _mockLambdaInstanceManager.Verify(l => l.CloseInstance(It.IsAny<LambdaInstance>(), It.IsAny<bool>()), Times.Never);
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherTests.cs
@@ -129,12 +129,14 @@ public class DispatcherTests
     var mockPoolOptions = new Mock<IPoolOptions>();
     var getCallbackIP = new Mock<IGetCallbackIP>();
     getCallbackIP.Setup(i => i.CallbackUrl).Returns("https://127.0.0.1:1000");
+    var mockLambdaClientConfig = new Mock<ILambdaClientConfig>();
     var manager = new LambdaInstanceManager(mockQueue.Object,
       mockConfig.Object,
       mockMetricsLogger.Object,
       mockPoolOptions.Object,
       getCallbackIP.Object,
-      _metricsRegistry.Object);
+      _metricsRegistry.Object,
+      lambdaClientConfig: mockLambdaClientConfig.Object);
     var dispatcher = new Dispatcher(_mockLogger.Object,
           _mockMetricsLogger.Object,
           manager,
@@ -146,7 +148,8 @@ public class DispatcherTests
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher,
       getCallbackIP: getCallbackIP.Object,
-      metricsRegistry: _metricsRegistry.Object
+      metricsRegistry: _metricsRegistry.Object,
+      lambdaClientConfig: mockLambdaClientConfig.Object
       );
 
     Assert.Multiple(() =>

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherTests.cs
@@ -7,7 +7,6 @@ using PwrDrvr.LambdaDispatch.Router.Tests.Mocks;
 
 namespace PwrDrvr.LambdaDispatch.Router.Tests;
 
-
 [TestFixture]
 public class DispatcherTests
 {
@@ -203,4 +202,5 @@ public class DispatcherTests
 
     shutdownSignal.Shutdown.Cancel();
   }
+
 }

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherTests.cs
@@ -182,7 +182,7 @@ public class DispatcherTests
       Assert.That(result.LambdaIDNotFound, Is.False, "LambdaIDNotFound");
       Assert.That(result.ImmediatelyDispatched, Is.False, "ImmediatelyDispatched");
       Assert.That(result.Connection, Is.Not.Null, "Connection");
-      Assert.That(result.Connection.State, Is.EqualTo(LambdaConnectionState.Open), "Connection.State");
+      Assert.That(result.Connection?.State, Is.EqualTo(LambdaConnectionState.Open), "Connection.State");
     });
 
     // Act
@@ -200,7 +200,7 @@ public class DispatcherTests
       Assert.That(result.LambdaIDNotFound, Is.False, "LambdaIDNotFound");
       Assert.That(result.ImmediatelyDispatched, Is.False, "ImmediatelyDispatched");
       Assert.That(result.Connection, Is.Not.Null, "Connection");
-      Assert.That(result.Connection.State, Is.EqualTo(LambdaConnectionState.Open), "Connection.State");
+      Assert.That(result.Connection?.State, Is.EqualTo(LambdaConnectionState.Open), "Connection.State");
     });
 
     shutdownSignal.Shutdown.Cancel();

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/DispatcherTests.cs
@@ -61,7 +61,7 @@ public class DispatcherTests
       _mockShutdownSignal.Object,
       metricsRegistry: _metricsRegistry.Object
     );
-    _mockLambdaInstanceManager.Setup(m => m.ValidateLambdaId(It.IsAny<string>(), out It.Ref<ILambdaInstance>.IsAny)).Returns(false);
+    _mockLambdaInstanceManager.Setup(m => m.ValidateLambdaId(It.IsAny<string>(), out It.Ref<ILambdaInstance?>.IsAny)).Returns(false);
 
     // Act
     var result = await dispatcher.AddConnectionForLambda(mockRequest.Object, mockResponse.Object, "lambdaId", "channelId");
@@ -90,7 +90,7 @@ public class DispatcherTests
     var mockConnection = new Mock<LambdaConnection>(mockRequest.Object, mockResponse.Object, mockInstance.Object, "channel-1", false);
     _mockLambdaInstanceManager.Setup(m => m.ValidateLambdaId(
         It.IsAny<string>(),
-        out It.Ref<ILambdaInstance>.IsAny))
+        out It.Ref<ILambdaInstance?>.IsAny))
       .Returns(true);
     _mockLambdaInstanceManager.Setup(m => m.AddConnectionForLambda(
         It.IsAny<HttpRequest>(),

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/GetCallbackIPTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/GetCallbackIPTests.cs
@@ -3,12 +3,10 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests;
 [TestFixture]
 public class GetCallbackIPTests
 {
-  private IGetCallbackIP getCallbackIP;
-
   [Test]
   public void Constructor_WhenCalled_SetsPropertiesAndReturnsUrl()
   {
-    getCallbackIP = new GetCallbackIP(5004, "https", "192.168.1.1");
+    var getCallbackIP = new GetCallbackIP(5004, "https", "192.168.1.1");
 
     var url = getCallbackIP.CallbackUrl;
 
@@ -18,6 +16,8 @@ public class GetCallbackIPTests
   [Test]
   public void Constructor_WhenNetworkIpIsNotSet_ThrowsException()
   {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
     Assert.Throws<ArgumentException>(() => new GetCallbackIP(5004, "https", null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
   }
 }

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/IncomingRequestMiddlewareTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/IncomingRequestMiddlewareTests.cs
@@ -1,0 +1,64 @@
+using Moq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace PwrDrvr.LambdaDispatch.Router.Tests;
+
+[TestFixture]
+public class IncomingRequestMiddlewareTests
+{
+  private Mock<RequestDelegate> _mockNext;
+  private Mock<IPoolManager> _mockPoolManager;
+  private IncomingRequestMiddleware _middleware;
+  private DefaultHttpContext _httpContext;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _mockNext = new Mock<RequestDelegate>();
+    _mockPoolManager = new Mock<IPoolManager>();
+    _middleware = new IncomingRequestMiddleware(_mockNext.Object, _mockPoolManager.Object, new int[] { 5001, 5002 });
+    _httpContext = new DefaultHttpContext();
+    _httpContext.Response.Body = new MemoryStream();
+    _httpContext.Features.Set<IHttpConnectionFeature>(new HttpConnectionFeature { LocalPort = 5001 });
+  }
+
+  [Test]
+  public async Task InvokeAsync_HealthCheck_ReturnsOk()
+  {
+    _httpContext.Request.Path = "/health";
+
+    await _middleware.InvokeAsync(_httpContext);
+
+    Assert.That(_httpContext.Response.StatusCode, Is.EqualTo(200));
+    _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+    var responseBody = new StreamReader(_httpContext.Response.Body).ReadToEnd();
+    Assert.That(responseBody, Is.EqualTo("OK"));
+  }
+
+  [Test]
+  public async Task InvokeAsync_ValidLambdaName_AddsRequestToDispatcher()
+  {
+    _httpContext.Request.Headers["X-Lambda-Name"] = "testLambda";
+
+    var mockDispatcher = new Mock<IDispatcher>();
+    var mockPool = new Mock<IPool>();
+    mockPool.Setup(p => p.Dispatcher).Returns(mockDispatcher.Object);
+    IPool outPool = mockPool.Object;
+    _mockPoolManager.Setup(m => m.GetOrCreatePoolByLambdaName(It.IsAny<string>())).Returns(mockPool.Object);
+
+    await _middleware.InvokeAsync(_httpContext);
+
+    mockDispatcher.Verify(m => m.AddRequest(_httpContext.Request, _httpContext.Response), Times.Once);
+  }
+
+  [Test]
+  public async Task InvokeAsync_InvalidPort_CallsNext()
+  {
+    _httpContext.Features.Set<IHttpConnectionFeature>(new HttpConnectionFeature { LocalPort = 5003 });
+
+    await _middleware.InvokeAsync(_httpContext);
+
+    _mockNext.Verify(f => f.Invoke(_httpContext), Times.Once);
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaClientConfigTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaClientConfigTests.cs
@@ -5,7 +5,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests;
 [TestFixture]
 public class LambdaClientConfigTests
 {
-  private string _originalServiceUrl;
+  private string? _originalServiceUrl;
 
   [SetUp]
   public void SetUp()

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaClientConfigTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaClientConfigTests.cs
@@ -1,0 +1,63 @@
+using Amazon.Lambda;
+
+namespace PwrDrvr.LambdaDispatch.Router.Tests;
+
+[TestFixture]
+public class LambdaClientConfigTests
+{
+  private string _originalServiceUrl;
+
+  [SetUp]
+  public void SetUp()
+  {
+    // Save the original value of the environment variable
+    _originalServiceUrl = Environment.GetEnvironmentVariable("AWS_LAMBDA_SERVICE_URL");
+
+    // Clear the environment variable
+    Environment.SetEnvironmentVariable("AWS_LAMBDA_SERVICE_URL", null);
+
+    // Set the AWS_REGION environment variable
+    Environment.SetEnvironmentVariable("AWS_REGION", "us-west-2");
+  }
+
+  [TearDown]
+  public void TearDown()
+  {
+    // Restore the original value of the environment variable
+    Environment.SetEnvironmentVariable("AWS_LAMBDA_SERVICE_URL", _originalServiceUrl);
+  }
+
+  [Test]
+  public void LambdaClient_DefaultConfig_Success()
+  {
+    var lambdaClientConfig = new LambdaClientConfig();
+    var lambdaClient = lambdaClientConfig.LambdaClient;
+
+    Assert.That(lambdaClient, Is.Not.Null);
+    Assert.That(lambdaClient, Is.InstanceOf<AmazonLambdaClient>());
+    Assert.Multiple(() =>
+    {
+      Assert.That(lambdaClient.Config.Timeout, Is.EqualTo(TimeSpan.FromMinutes(15)));
+      Assert.That(lambdaClient.Config.MaxErrorRetry, Is.EqualTo(1));
+      Assert.That(lambdaClient.Config.ServiceURL, Is.Null);
+    });
+  }
+
+  [Test]
+  public void LambdaClient_ServiceUrlConfig_Success()
+  {
+    Environment.SetEnvironmentVariable("AWS_LAMBDA_SERVICE_URL", "http://localhost:5051");
+
+    var lambdaClientConfig = new LambdaClientConfig();
+    var lambdaClient = lambdaClientConfig.LambdaClient;
+
+    Assert.That(lambdaClient, Is.Not.Null);
+    Assert.That(lambdaClient, Is.InstanceOf<AmazonLambdaClient>());
+    Assert.Multiple(() =>
+    {
+      Assert.That(lambdaClient.Config.Timeout, Is.EqualTo(TimeSpan.FromMinutes(15)));
+      Assert.That(lambdaClient.Config.MaxErrorRetry, Is.EqualTo(1));
+      Assert.That(lambdaClient.Config.ServiceURL, Is.EqualTo("http://localhost:5051/"));
+    });
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceManagerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceManagerTests.cs
@@ -10,6 +10,8 @@ using PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
 [TestFixture]
 public class LambdaInstanceManagerTests
 {
+  private Mock<IMetricsRegistry> metricsRegistry = new Mock<IMetricsRegistry>();
+
   [Test]
   public async Task AddConnectionForLambda_WhenLambdaDoesNotExist()
   {
@@ -31,7 +33,12 @@ public class LambdaInstanceManagerTests
     var getCallbackIP = new Mock<IGetCallbackIP>();
     getCallbackIP.Setup(i => i.CallbackUrl).Returns("https://127.0.0.1:1000");
 
-    var manager = new LambdaInstanceManager(mockQueue.Object, mockConfig.Object, mockMetricsLogger.Object, mockPoolOptions.Object, getCallbackIP.Object);
+    var manager = new LambdaInstanceManager(mockQueue.Object,
+      mockConfig.Object,
+      mockMetricsLogger.Object,
+      mockPoolOptions.Object,
+      getCallbackIP.Object,
+      metricsRegistry.Object);
 
     var expectedConnectionResult = new AddConnectionResult()
     {
@@ -73,7 +80,12 @@ public class LambdaInstanceManagerTests
     var getCallbackIP = new Mock<IGetCallbackIP>();
     getCallbackIP.Setup(i => i.CallbackUrl).Returns("https://127.0.0.1:1000");
 
-    var manager = new LambdaInstanceManager(mockQueue.Object, mockConfig.Object, mockMetricsLogger.Object, mockPoolOptions.Object, getCallbackIP.Object);
+    var manager = new LambdaInstanceManager(mockQueue.Object,
+      mockConfig.Object,
+      mockMetricsLogger.Object,
+      mockPoolOptions.Object,
+      getCallbackIP.Object,
+      metricsRegistry.Object);
     manager.TryAddInstance(mockInstance.Object);
     // Raise the OnOpen event to get the manager to think it has an instance
     mockInstance.Raise(m => m.OnOpen += null, mockInstance.Object);
@@ -122,7 +134,12 @@ public class LambdaInstanceManagerTests
     var getCallbackIP = new Mock<IGetCallbackIP>();
     getCallbackIP.Setup(i => i.CallbackUrl).Returns("https://127.0.0.1:1000");
 
-    var manager = new LambdaInstanceManager(mockQueue.Object, mockConfig.Object, mockMetricsLogger.Object, mockPoolOptions.Object, getCallbackIP.Object);
+    var manager = new LambdaInstanceManager(mockQueue.Object,
+      mockConfig.Object,
+      mockMetricsLogger.Object,
+      mockPoolOptions.Object,
+      getCallbackIP.Object,
+      metricsRegistry.Object);
     manager.TryAddInstance(mockInstance.Object);
     // Raise the OnOpen event to get the manager to think it has an instance
     mockInstance.Raise(m => m.OnOpen += null, mockInstance.Object);
@@ -170,7 +187,12 @@ public class LambdaInstanceManagerTests
     var mockPoolOptions = new Mock<IPoolOptions>();
     var getCallbackIP = new Mock<IGetCallbackIP>();
     getCallbackIP.Setup(i => i.CallbackUrl).Returns("https://127.0.0.1:1000");
-    var manager = new LambdaInstanceManager(mockQueue.Object, mockConfig.Object, mockMetricsLogger.Object, mockPoolOptions.Object, getCallbackIP.Object);
+    var manager = new LambdaInstanceManager(mockQueue.Object,
+      mockConfig.Object,
+      mockMetricsLogger.Object,
+      mockPoolOptions.Object,
+      getCallbackIP.Object,
+      metricsRegistry.Object);
     manager.TryAddInstance(mockInstance.Object);
     // Raise the OnOpen event to get the manager to think it has an instance
     mockInstance.Raise(m => m.OnOpen += null, mockInstance.Object);
@@ -218,7 +240,13 @@ public class LambdaInstanceManagerTests
     var mockPoolOptions = new Mock<IPoolOptions>();
     var getCallbackIP = new Mock<IGetCallbackIP>();
     getCallbackIP.Setup(i => i.CallbackUrl).Returns("https://127.0.0.1:1000");
-    var manager = new LambdaInstanceManager(mockQueue.Object, mockConfig.Object, mockMetricsLogger.Object, mockPoolOptions.Object, getCallbackIP: getCallbackIP.Object);
+    var manager = new LambdaInstanceManager(
+      mockQueue.Object,
+      mockConfig.Object,
+      mockMetricsLogger.Object,
+      mockPoolOptions.Object,
+      getCallbackIP: getCallbackIP.Object,
+      metricsRegistry: metricsRegistry.Object);
     manager.TryAddInstance(mockInstance.Object);
     // Raise the OnOpen event to get the manager to think it has an instance
     mockInstance.Raise(m => m.OnOpen += null, mockInstance.Object);

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceManagerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceManagerTests.cs
@@ -11,6 +11,7 @@ using PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
 public class LambdaInstanceManagerTests
 {
   private Mock<IMetricsRegistry> metricsRegistry = new Mock<IMetricsRegistry>();
+  private Mock<ILambdaClientConfig> mockLambdaClientConfig = new Mock<ILambdaClientConfig>();
 
   [Test]
   public async Task AddConnectionForLambda_WhenLambdaDoesNotExist()
@@ -38,7 +39,8 @@ public class LambdaInstanceManagerTests
       mockMetricsLogger.Object,
       mockPoolOptions.Object,
       getCallbackIP.Object,
-      metricsRegistry.Object);
+      metricsRegistry.Object,
+      lambdaClientConfig: mockLambdaClientConfig.Object);
 
     var expectedConnectionResult = new AddConnectionResult()
     {
@@ -85,7 +87,8 @@ public class LambdaInstanceManagerTests
       mockMetricsLogger.Object,
       mockPoolOptions.Object,
       getCallbackIP.Object,
-      metricsRegistry.Object);
+      metricsRegistry.Object,
+      lambdaClientConfig: mockLambdaClientConfig.Object);
     manager.TryAddInstance(mockInstance.Object);
     // Raise the OnOpen event to get the manager to think it has an instance
     mockInstance.Raise(m => m.OnOpen += null, mockInstance.Object);
@@ -139,7 +142,8 @@ public class LambdaInstanceManagerTests
       mockMetricsLogger.Object,
       mockPoolOptions.Object,
       getCallbackIP.Object,
-      metricsRegistry.Object);
+      metricsRegistry.Object,
+      lambdaClientConfig: mockLambdaClientConfig.Object);
     manager.TryAddInstance(mockInstance.Object);
     // Raise the OnOpen event to get the manager to think it has an instance
     mockInstance.Raise(m => m.OnOpen += null, mockInstance.Object);
@@ -192,7 +196,8 @@ public class LambdaInstanceManagerTests
       mockMetricsLogger.Object,
       mockPoolOptions.Object,
       getCallbackIP.Object,
-      metricsRegistry.Object);
+      metricsRegistry.Object,
+      lambdaClientConfig: mockLambdaClientConfig.Object);
     manager.TryAddInstance(mockInstance.Object);
     // Raise the OnOpen event to get the manager to think it has an instance
     mockInstance.Raise(m => m.OnOpen += null, mockInstance.Object);
@@ -246,7 +251,8 @@ public class LambdaInstanceManagerTests
       mockMetricsLogger.Object,
       mockPoolOptions.Object,
       getCallbackIP: getCallbackIP.Object,
-      metricsRegistry: metricsRegistry.Object);
+      metricsRegistry: metricsRegistry.Object,
+      lambdaClientConfig: mockLambdaClientConfig.Object);
     manager.TryAddInstance(mockInstance.Object);
     // Raise the OnOpen event to get the manager to think it has an instance
     mockInstance.Raise(m => m.OnOpen += null, mockInstance.Object);

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
@@ -403,6 +403,7 @@ public class LambdaInstanceTests
     });
 
     // Reinstate the connection
+    Assert.That(connection, Is.Not.Null);
     instance.ReenqueueUnusedConnection(connection);
     Assert.Multiple(() =>
     {

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using Amazon.Lambda;
 using Microsoft.AspNetCore.Http;
+using PwrDrvr.LambdaDispatch.Router.Tests.Mocks;
 
 namespace PwrDrvr.LambdaDispatch.Router.Tests;
 
@@ -24,6 +25,8 @@ public class TransitionResultTests
 
 public class LambdaInstanceTests
 {
+  private Mock<IMetricsRegistry> metricsRegistry = MetricsRegistryMockFactory.Create();
+
   [SetUp]
   public void Setup()
   {
@@ -36,8 +39,20 @@ public class LambdaInstanceTests
     var dispatcher = new Mock<IBackgroundDispatcher>();
     var getCallbackIP = new Mock<IGetCallbackIP>();
 
-    Assert.Throws<ArgumentOutOfRangeException>(() => new LambdaInstance(maxConcurrentCount: 0, functionName: "somefunc", poolId: "default", lambdaClient: lambdaClient.Object, dispatcher: dispatcher.Object, getCallbackIP: getCallbackIP.Object));
-    Assert.Throws<ArgumentOutOfRangeException>(() => new LambdaInstance(maxConcurrentCount: -1, functionName: "somefunc", poolId: "default", lambdaClient: lambdaClient.Object, dispatcher: dispatcher.Object, getCallbackIP: getCallbackIP.Object));
+    Assert.Throws<ArgumentOutOfRangeException>(() => new LambdaInstance(maxConcurrentCount: 0,
+      functionName: "somefunc",
+      poolId: "default",
+      lambdaClient: lambdaClient.Object,
+      dispatcher: dispatcher.Object,
+      getCallbackIP: getCallbackIP.Object,
+      metricsRegistry: metricsRegistry.Object));
+    Assert.Throws<ArgumentOutOfRangeException>(() => new LambdaInstance(maxConcurrentCount: -1,
+      functionName: "somefunc",
+      poolId: "default",
+      lambdaClient: lambdaClient.Object,
+      dispatcher: dispatcher.Object,
+      getCallbackIP: getCallbackIP.Object,
+      metricsRegistry: metricsRegistry.Object));
   }
 
   [Test]
@@ -53,7 +68,8 @@ public class LambdaInstanceTests
       poolId: "default",
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
-      getCallbackIP: getCallbackIP.Object
+      getCallbackIP: getCallbackIP.Object,
+      metricsRegistry: metricsRegistry.Object
       );
 
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
@@ -126,7 +142,8 @@ public class LambdaInstanceTests
           poolId: "default",
           lambdaClient: lambdaClient.Object,
           dispatcher: dispatcher.Object,
-          getCallbackIP: getCallbackIP.Object
+          getCallbackIP: getCallbackIP.Object,
+          metricsRegistry: metricsRegistry.Object
           );
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
     var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
@@ -192,7 +209,8 @@ public class LambdaInstanceTests
       poolId: "default",
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
-      getCallbackIP: getCallbackIP.Object
+      getCallbackIP: getCallbackIP.Object,
+      metricsRegistry: metricsRegistry.Object
       );
 
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
@@ -267,7 +285,8 @@ public class LambdaInstanceTests
       poolId: "default",
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
-      getCallbackIP: getCallbackIP.Object
+      getCallbackIP: getCallbackIP.Object,
+      metricsRegistry: metricsRegistry.Object
       );
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
     var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
@@ -336,7 +355,8 @@ public class LambdaInstanceTests
       poolId: "default",
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
-      getCallbackIP: getCallbackIP.Object
+      getCallbackIP: getCallbackIP.Object,
+      metricsRegistry: metricsRegistry.Object
       );
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
     var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LambdaInstanceTests.cs
@@ -26,6 +26,7 @@ public class TransitionResultTests
 public class LambdaInstanceTests
 {
   private Mock<IMetricsRegistry> metricsRegistry = MetricsRegistryMockFactory.Create();
+  private Mock<ILambdaClientConfig> lambdaClientConfig = new Mock<ILambdaClientConfig>();
 
   [SetUp]
   public void Setup()
@@ -45,14 +46,16 @@ public class LambdaInstanceTests
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
       getCallbackIP: getCallbackIP.Object,
-      metricsRegistry: metricsRegistry.Object));
+      metricsRegistry: metricsRegistry.Object,
+      lambdaClientConfig: lambdaClientConfig.Object));
     Assert.Throws<ArgumentOutOfRangeException>(() => new LambdaInstance(maxConcurrentCount: -1,
       functionName: "somefunc",
       poolId: "default",
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
       getCallbackIP: getCallbackIP.Object,
-      metricsRegistry: metricsRegistry.Object));
+      metricsRegistry: metricsRegistry.Object,
+      lambdaClientConfig: lambdaClientConfig.Object));
   }
 
   [Test]
@@ -69,7 +72,8 @@ public class LambdaInstanceTests
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
       getCallbackIP: getCallbackIP.Object,
-      metricsRegistry: metricsRegistry.Object
+      metricsRegistry: metricsRegistry.Object,
+      lambdaClientConfig: lambdaClientConfig.Object
       );
 
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
@@ -143,7 +147,8 @@ public class LambdaInstanceTests
           lambdaClient: lambdaClient.Object,
           dispatcher: dispatcher.Object,
           getCallbackIP: getCallbackIP.Object,
-          metricsRegistry: metricsRegistry.Object
+          metricsRegistry: metricsRegistry.Object,
+          lambdaClientConfig: lambdaClientConfig.Object
           );
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
     var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
@@ -210,7 +215,8 @@ public class LambdaInstanceTests
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
       getCallbackIP: getCallbackIP.Object,
-      metricsRegistry: metricsRegistry.Object
+      metricsRegistry: metricsRegistry.Object,
+      lambdaClientConfig: lambdaClientConfig.Object
       );
 
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
@@ -286,7 +292,8 @@ public class LambdaInstanceTests
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
       getCallbackIP: getCallbackIP.Object,
-      metricsRegistry: metricsRegistry.Object
+      metricsRegistry: metricsRegistry.Object,
+      lambdaClientConfig: lambdaClientConfig.Object
       );
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
     var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();
@@ -356,7 +363,8 @@ public class LambdaInstanceTests
       lambdaClient: lambdaClient.Object,
       dispatcher: dispatcher.Object,
       getCallbackIP: getCallbackIP.Object,
-      metricsRegistry: metricsRegistry.Object
+      metricsRegistry: metricsRegistry.Object,
+      lambdaClientConfig: lambdaClientConfig.Object
       );
     var requestContext = new Mock<Microsoft.AspNetCore.Http.HttpContext>();
     var request = new Mock<Microsoft.AspNetCore.Http.HttpRequest>();

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
@@ -6,11 +6,13 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
   public class LeastOutstandingQueueTests
   {
     private Mock<IMetricsRegistry> _metricsRegistry;
+    private Mock<ILambdaClientConfig> _mockLambdaClientConfig;
 
     [SetUp]
     public void Setup()
     {
       _metricsRegistry = new Mock<IMetricsRegistry>();
+      _mockLambdaClientConfig = new Mock<ILambdaClientConfig>();
     }
 
     [Test]
@@ -52,7 +54,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
             lambdaClient: lambdaClient.Object,
             dispatcher: dispatcher.Object,
             getCallbackIP: getCallbackIP.Object,
-            metricsRegistry: _metricsRegistry.Object
+            metricsRegistry: _metricsRegistry.Object,
+            lambdaClientConfig: _mockLambdaClientConfig.Object
             );
       queue.AddInstance(instance);
 

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
@@ -78,7 +78,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       instance.Setup(i => i.State).Returns(LambdaInstanceState.Open);
       instance.Setup(i => i.IsOpen).Returns(true);
       instance.Setup(i => i.AvailableConnectionCount).Returns(1);
-      var connectionObject = connection.Object;
+      var connectionObject = connection.Object as ILambdaConnection;
       instance.Setup(i => i.TryGetConnection(out connectionObject, false)).Returns(true);
 
       using var queue = new LeastOutstandingQueue(config.Object);
@@ -125,7 +125,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       instance.Setup(i => i.IsOpen).Returns(true);
       instance.Setup(i => i.AvailableConnectionCount).Returns(1);
       instance.Setup(i => i.OutstandingRequestCount).Returns(0);
-      var connectionObject = connection.Object;
+      var connectionObject = connection.Object as ILambdaConnection;
       instance.Setup(i => i.TryGetConnection(out connectionObject, false)).Returns(true);
 
       // Add the instance
@@ -167,7 +167,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       instance.Setup(i => i.IsOpen).Returns(true);
       instance.Setup(i => i.AvailableConnectionCount).Returns(0);
       instance.Setup(i => i.OutstandingRequestCount).Returns(1);
-      var connectionObject = connection.Object;
+      var connectionObject = connection.Object as ILambdaConnection;
       instance.Setup(i => i.TryGetConnection(out connectionObject, false)).Returns(true);
 
       // Add the instance
@@ -216,7 +216,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       instance.Setup(i => i.IsOpen).Returns(true);
       instance.SetupSequence(i => i.AvailableConnectionCount).Returns(1).Returns(1).Returns(0);
       instance.Setup(i => i.OutstandingRequestCount).Returns(1);
-      var connectionObject = connection.Object;
+      var connectionObject = connection.Object as ILambdaConnection;
       instance.Setup(i => i.TryGetConnection(out connectionObject, false)).Returns(true);
 
       // Add the instance

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
@@ -5,9 +5,12 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 {
   public class LeastOutstandingQueueTests
   {
+    private Mock<IMetricsRegistry> _metricsRegistry;
+
     [SetUp]
     public void Setup()
     {
+      _metricsRegistry = new Mock<IMetricsRegistry>();
     }
 
     [Test]
@@ -48,7 +51,8 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
             poolId: "default",
             lambdaClient: lambdaClient.Object,
             dispatcher: dispatcher.Object,
-            getCallbackIP: getCallbackIP.Object
+            getCallbackIP: getCallbackIP.Object,
+            metricsRegistry: _metricsRegistry.Object
             );
       queue.AddInstance(instance);
 

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/LeastOutstandingQueueTests.cs
@@ -33,7 +33,9 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       config.Setup(c => c.MaxConcurrentCount).Returns(maxConcurrentCount);
       using var queue = new LeastOutstandingQueue(config.Object);
 
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
       Assert.Throws<ArgumentNullException>(() => queue.AddInstance(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Test]

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
@@ -49,7 +49,7 @@ public class MetadataServiceTests
   [Test]
   public void Test_Local_IpSourceType()
   {
-    var service = new MetadataService(_httpClientFactoryMock.Object, configWithoutRouterCallbackHost);
+    var service = new MetadataService(configWithoutRouterCallbackHost, _httpClientFactoryMock.Object);
     Assert.Multiple(() =>
    {
      Assert.That(service.NetworkIP, Is.EqualTo("127.0.0.1"));
@@ -62,7 +62,7 @@ public class MetadataServiceTests
   {
     Environment.SetEnvironmentVariable("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE");
     Environment.SetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4", "http://localhost:1000/v4/metadata");
-    var service = new MetadataService(_httpClientFactoryMock.Object, configWithoutRouterCallbackHost);
+    var service = new MetadataService(configWithoutRouterCallbackHost, _httpClientFactoryMock.Object);
     Assert.Multiple(() =>
     {
       Assert.That(service.NetworkIP, Is.EqualTo("192.168.0.1"));
@@ -74,7 +74,7 @@ public class MetadataServiceTests
   public void Test_EnvVar_IpSourceType()
   {
     Environment.SetEnvironmentVariable("K8S_POD_IP", "10.1.1.1");
-    var service = new MetadataService(_httpClientFactoryMock.Object, configWithoutRouterCallbackHost);
+    var service = new MetadataService(configWithoutRouterCallbackHost, _httpClientFactoryMock.Object);
     Assert.Multiple(() =>
     {
       Assert.That(service.NetworkIP, Is.EqualTo("10.1.1.1"));
@@ -87,7 +87,7 @@ public class MetadataServiceTests
   {
     var configWithEnvVarForCallbackIp = new Config { EnvVarForCallbackIp = "IP_FROM_ELSEWHERE" };
     Environment.SetEnvironmentVariable("IP_FROM_ELSEWHERE", "10.3.2.1");
-    var service = new MetadataService(_httpClientFactoryMock.Object, configWithEnvVarForCallbackIp);
+    var service = new MetadataService(configWithEnvVarForCallbackIp, _httpClientFactoryMock.Object);
     Assert.Multiple(() =>
     {
       Assert.That(service.NetworkIP, Is.EqualTo("10.3.2.1"));
@@ -103,11 +103,11 @@ public class MockHttpMessageHandler : HttpMessageHandler
     var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
 
     // Set the content of the response message based on the request URL
-    if (request.RequestUri.ToString() == Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4"))
+    if (request.RequestUri?.ToString() == Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4"))
     {
       responseMessage.Content = new StringContent("{ \"Networks\": [ { \"NetworkMode\": \"awsvpc\", \"IPv4Addresses\": [ \"192.168.0.1\" ] } ] }");
     }
-    if (request.RequestUri.ToString() == $"{Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4")}/task")
+    if (request.RequestUri?.ToString() == $"{Environment.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4")}/task")
     {
       responseMessage.Content = new StringContent("{ \"TaskARN\": \"arn:aws:ecs:us-west-2:123456789012:task/test_cluster/abcdefg\" }");
     }

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/MetricsLoggerTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/MetricsLoggerTests.cs
@@ -1,0 +1,98 @@
+using PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics;
+
+namespace PwrDrvr.LambdaDispatch.Router.EmbeddedMetrics.Tests;
+
+[TestFixture]
+public class MetricsLoggerTests
+{
+  private MetricsLogger _metricsLogger;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _metricsLogger = new MetricsLogger("TestNamespace");
+  }
+
+  [Test]
+  public void PutMetric_ValidInput_Success()
+  {
+    Assert.DoesNotThrow(() => _metricsLogger.PutMetric("TestMetric", 1.0, Unit.Count));
+  }
+
+  [Test]
+  public void PutMetric_Overflow_Channel()
+  {
+    for (int i = 0; i < 1000; i++)
+    {
+      Assert.DoesNotThrow(() => _metricsLogger.PutMetric("TestMetric", 1.0, Unit.Count));
+    }
+    _metricsLogger.Dispose();
+
+    Thread.Sleep(1000);
+  }
+
+  [Test]
+  public void Flush_Success()
+  {
+    // Wait 1 second for flush to run first time
+    Thread.Sleep(1000);
+    Assert.DoesNotThrow(() => _metricsLogger.PutMetric("TestMetric", 1.0, Unit.Count));
+  }
+
+  [Test]
+  public void MetricsLogger_Dimensions_Valid()
+  {
+    var dimensions = new Dictionary<string, string>();
+    for (int i = 0; i < 5; i++)
+    {
+      dimensions.Add($"key{i}", $"value{i}");
+    }
+
+    Assert.DoesNotThrow(() => new MetricsLogger("TestNamespace", dimensions));
+  }
+
+  [Test]
+  public void MetricsLogger_TooManyDimensions_ThrowsException()
+  {
+    var dimensions = new Dictionary<string, string>();
+    for (int i = 0; i < 31; i++)
+    {
+      dimensions.Add($"key{i}", $"value{i}");
+    }
+
+    Assert.Throws<ArgumentException>(() => new MetricsLogger("TestNamespace", dimensions));
+  }
+
+  [Test]
+  public void MetricsLogger_InvalidDimensionType_ThrowsException()
+  {
+    var dimensions = new Dictionary<string, string>();
+    for (int i = 0; i < 10; i++)
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+      dimensions.Add($"key{i}", null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+
+    Assert.Throws<ArgumentException>(() => new MetricsLogger("TestNamespace", dimensions));
+  }
+
+  [Test]
+  public void MetricsLogger_DimensionValueTooLong_ThrowsException()
+  {
+    var dimensions = new Dictionary<string, string>
+            {
+                { "key", new string('a', 1025) }
+            };
+
+    Assert.Throws<ArgumentException>(() => new MetricsLogger("TestNamespace", dimensions));
+  }
+
+  [Test]
+  public void Dispose_CancelsBackgroundTask()
+  {
+    _metricsLogger.Dispose();
+
+    Assert.Throws<ObjectDisposedException>(() => _metricsLogger.PutMetric("TestMetric", 1.0, Unit.Count));
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/MetricsRegistryTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/MetricsRegistryTests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+using App.Metrics;
+using App.Metrics.Counter;
+using App.Metrics.Histogram;
+using App.Metrics.Timer;
+
+namespace PwrDrvr.LambdaDispatch.Router.Tests;
+
+[TestFixture]
+public class MetricsRegistryTests
+{
+  private MetricsRegistry _metricsRegistry;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _metricsRegistry = new MetricsRegistry();
+  }
+
+  [Test]
+  public void MetricsRegistry_CounterOptions_Success()
+  {
+    CounterOptions counterOption = _metricsRegistry.RequestCount;
+    Assert.That(counterOption, Is.Not.Null);
+    Assert.Multiple(() =>
+    {
+      Assert.That(counterOption.Name, Is.EqualTo("RequestCount"));
+      Assert.That(counterOption.MeasurementUnit, Is.EqualTo(Unit.Requests));
+    });
+  }
+
+  [Test]
+  public void MetricsRegistry_HistogramOptions_Success()
+  {
+    HistogramOptions histogramOption = _metricsRegistry.DispatchDelay;
+    Assert.That(histogramOption, Is.Not.Null);
+    Assert.Multiple(() =>
+    {
+      Assert.That(histogramOption.Name, Is.EqualTo("DispatchDelay"));
+      Assert.That(histogramOption.MeasurementUnit, Is.EqualTo(Unit.Custom("ms")));
+    });
+  }
+
+  [Test]
+  public void MetricsRegistry_TimerOptions_Success()
+  {
+    TimerOptions timerOption = _metricsRegistry.LambdaRequestTimer;
+    Assert.That(timerOption, Is.Not.Null);
+    Assert.Multiple(() =>
+    {
+      Assert.That(timerOption.Name, Is.EqualTo("LambdaRequestTimer"));
+      Assert.That(timerOption.MeasurementUnit, Is.EqualTo(Unit.Custom("ms")));
+    });
+  }
+
+  [Test]
+  public void MetricsRegistry_Reset_Success()
+  {
+    Assert.DoesNotThrow(() => _metricsRegistry.Reset());
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Mocks/MetricsRegistry.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Mocks/MetricsRegistry.cs
@@ -1,0 +1,36 @@
+using Moq;
+using App.Metrics;
+using App.Metrics.Counter;
+using App.Metrics.Histogram;
+using App.Metrics.Gauge;
+using App.Metrics.Timer;
+
+namespace PwrDrvr.LambdaDispatch.Router.Tests.Mocks;
+
+public static class MetricsRegistryMockFactory
+{
+  public static Mock<IMetricsRegistry> Create()
+  {
+    var mockMetricsRegistry = new Mock<IMetricsRegistry>();
+    var mockMetricsRoot = new Mock<IMetricsRoot>();
+    var mockMeasure = new Mock<IMeasureMetrics>();
+    var mockCounter = new Mock<IMeasureCounterMetrics>();
+    var mockHistogram = new Mock<IMeasureHistogramMetrics>();
+    var mockGauge = new Mock<IMeasureGaugeMetrics>();
+    var mockTimer = new Mock<IMeasureTimerMetrics>();
+
+    mockMetricsRegistry.Setup(mr => mr.Metrics).Returns(mockMetricsRoot.Object);
+    mockMetricsRoot.Setup(mr => mr.Measure).Returns(mockMeasure.Object);
+    mockMeasure.Setup(m => m.Counter).Returns(mockCounter.Object);
+    mockMeasure.Setup(m => m.Histogram).Returns(mockHistogram.Object);
+    mockMeasure.Setup(m => m.Gauge).Returns(mockGauge.Object);
+    mockMeasure.Setup(m => m.Timer).Returns(mockTimer.Object);
+
+    mockCounter.Setup(c => c.Increment(It.IsAny<CounterOptions>())).Verifiable();
+    mockHistogram.Setup(h => h.Update(It.IsAny<HistogramOptions>(), It.IsAny<long>())).Verifiable();
+    mockGauge.Setup(g => g.SetValue(It.IsAny<GaugeOptions>(), It.IsAny<double>())).Verifiable();
+    mockTimer.Setup(t => t.Time(It.IsAny<TimerOptions>())).Returns(() => new TimerContext()).Verifiable();
+
+    return mockMetricsRegistry;
+  }
+}

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/Mocks/MetricsRegistry.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/Mocks/MetricsRegistry.cs
@@ -3,6 +3,7 @@ using App.Metrics;
 using App.Metrics.Counter;
 using App.Metrics.Histogram;
 using App.Metrics.Gauge;
+using App.Metrics.Meter;
 using App.Metrics.Timer;
 
 namespace PwrDrvr.LambdaDispatch.Router.Tests.Mocks;
@@ -18,6 +19,7 @@ public static class MetricsRegistryMockFactory
     var mockHistogram = new Mock<IMeasureHistogramMetrics>();
     var mockGauge = new Mock<IMeasureGaugeMetrics>();
     var mockTimer = new Mock<IMeasureTimerMetrics>();
+    var mockMeter = new Mock<IMeasureMeterMetrics>();
 
     mockMetricsRegistry.Setup(mr => mr.Metrics).Returns(mockMetricsRoot.Object);
     mockMetricsRoot.Setup(mr => mr.Measure).Returns(mockMeasure.Object);
@@ -25,11 +27,13 @@ public static class MetricsRegistryMockFactory
     mockMeasure.Setup(m => m.Histogram).Returns(mockHistogram.Object);
     mockMeasure.Setup(m => m.Gauge).Returns(mockGauge.Object);
     mockMeasure.Setup(m => m.Timer).Returns(mockTimer.Object);
+    mockMeasure.Setup(m => m.Meter).Returns(mockMeter.Object);
 
     mockCounter.Setup(c => c.Increment(It.IsAny<CounterOptions>())).Verifiable();
     mockHistogram.Setup(h => h.Update(It.IsAny<HistogramOptions>(), It.IsAny<long>())).Verifiable();
     mockGauge.Setup(g => g.SetValue(It.IsAny<GaugeOptions>(), It.IsAny<double>())).Verifiable();
     mockTimer.Setup(t => t.Time(It.IsAny<TimerOptions>())).Returns(() => new TimerContext()).Verifiable();
+    mockMeter.Setup(m => m.Mark(It.IsAny<MeterOptions>())).Verifiable();
 
     return mockMetricsRegistry;
   }

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/PendingRequestTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/PendingRequestTests.cs
@@ -77,6 +77,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
     }
 
     [Test]
+    [Retry(3)]
     public void TestDurationAfterDispatch()
     {
       var mockRequest = new Mock<HttpRequest>();

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/PendingRequestTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/PendingRequestTests.cs
@@ -16,12 +16,14 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var mockResponse = new Mock<HttpResponse>();
 
       var pendingRequest = new PendingRequest(mockRequest.Object, mockResponse.Object);
-
-      Assert.AreEqual(mockRequest.Object, pendingRequest.Request);
-      Assert.AreEqual(mockResponse.Object, pendingRequest.Response);
-      Assert.IsFalse(pendingRequest.Dispatched);
-      Assert.IsNotNull(pendingRequest.ResponseFinishedTCS);
-      Assert.IsNotNull(pendingRequest.GatewayTimeoutCTS);
+      Assert.Multiple(() =>
+      {
+        Assert.That(pendingRequest.Request, Is.EqualTo(mockRequest.Object));
+        Assert.That(pendingRequest.Response, Is.EqualTo(mockResponse.Object));
+        Assert.That(pendingRequest.Dispatched, Is.False);
+        Assert.That(pendingRequest.ResponseFinishedTCS, Is.Not.Null);
+        Assert.That(pendingRequest.GatewayTimeoutCTS, Is.Not.Null);
+      });
     }
 
     [Test]
@@ -32,11 +34,11 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       var pendingRequest = new PendingRequest(mockRequest.Object, mockResponse.Object);
 
-      Assert.IsFalse(pendingRequest.GatewayTimeoutCTS.IsCancellationRequested);
+      Assert.That(pendingRequest.GatewayTimeoutCTS.IsCancellationRequested, Is.False);
 
       pendingRequest.Abort();
 
-      Assert.IsTrue(pendingRequest.GatewayTimeoutCTS.IsCancellationRequested);
+      Assert.That(pendingRequest.GatewayTimeoutCTS.IsCancellationRequested, Is.True);
     }
 
     [Test]
@@ -47,11 +49,11 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       var pendingRequest = new PendingRequest(mockRequest.Object, mockResponse.Object);
 
-      Assert.IsFalse(pendingRequest.Dispatched);
+      Assert.That(pendingRequest.Dispatched, Is.False);
 
       pendingRequest.RecordDispatchTime();
 
-      Assert.IsTrue(pendingRequest.Dispatched);
+      Assert.That(pendingRequest.Dispatched, Is.True);
     }
 
     [Test]
@@ -62,7 +64,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       var pendingRequest = new PendingRequest(mockRequest.Object, mockResponse.Object);
 
-      Assert.IsTrue(pendingRequest.DispatchDelay.TotalMilliseconds >= 0);
+      Assert.That(pendingRequest.DispatchDelay.TotalMilliseconds >= 0, Is.True);
     }
 
     [Test]
@@ -73,7 +75,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       var pendingRequest = new PendingRequest(mockRequest.Object, mockResponse.Object);
 
-      Assert.IsTrue(pendingRequest.Duration.TotalMilliseconds >= 0);
+      Assert.That(pendingRequest.Duration.TotalMilliseconds >= 0, Is.True);
     }
 
     [Test]
@@ -85,11 +87,11 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
 
       var pendingRequest = new PendingRequest(mockRequest.Object, mockResponse.Object);
 
-      Assert.IsTrue(pendingRequest.DurationAfterDispatch.TotalMilliseconds >= 0);
+      Assert.That(pendingRequest.DurationAfterDispatch.TotalMilliseconds >= 0, Is.True);
 
       pendingRequest.RecordDispatchTime();
 
-      Assert.IsTrue(pendingRequest.DurationAfterDispatch.TotalMilliseconds >= 0);
+      Assert.That(pendingRequest.DurationAfterDispatch.TotalMilliseconds >= 0, Is.True);
     }
   }
 }

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/PoolTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/PoolTests.cs
@@ -19,7 +19,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var result = pool.Dispatcher;
 
       // Assert
-      Assert.AreEqual(mockDispatcher.Object, result);
+      Assert.That(result, Is.EqualTo(mockDispatcher.Object));
     }
 
     [Test]
@@ -34,7 +34,7 @@ namespace PwrDrvr.LambdaDispatch.Router.Tests
       var result = pool.PoolId;
 
       // Assert
-      Assert.AreEqual(poolId, result);
+      Assert.That(result, Is.EqualTo(poolId));
     }
   }
 }

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/RoundRobinLambdaInstanceQueue2Tests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/RoundRobinLambdaInstanceQueue2Tests.cs
@@ -30,18 +30,18 @@ public class RoundRobinLambdaInstanceQueue2Tests
 
     _mockClosedInstance.SetupGet(i => i.IsOpen).Returns(false);
     _mockOpenInstance.SetupGet(i => i.IsOpen).Returns(true);
-    _mockOpenInstance.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
+    _mockOpenInstance.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
     _queue.AddInstance(_mockClosedInstance.Object);
     _queue.AddInstance(_mockClosedInstance.Object);
     _queue.AddInstance(_mockClosedInstance.Object);
     _queue.AddInstance(_mockOpenInstance.Object);
     _queue.AddInstance(_mockClosedInstance.Object);
 
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.True);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.True);
     Assert.That(_queue.TryGetConnection(out connection), Is.True);
-    _mockOpenInstance.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    _mockOpenInstance.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
     _mockOpenInstance.Verify(i => i.IsOpen, Times.Exactly(2));
-    _mockClosedInstance.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Never);
+    _mockClosedInstance.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Never);
     _mockClosedInstance.Verify(i => i.IsOpen, Times.Exactly(7));
 
     Assert.That(_queue.TryRemoveInstance(out ILambdaInstance? instance), Is.True);
@@ -50,7 +50,7 @@ public class RoundRobinLambdaInstanceQueue2Tests
     _mockClosedInstance.Verify(i => i.IsOpen, Times.Exactly(11));
 
     Assert.That(_queue.TryGetConnection(out connection), Is.False);
-    _mockOpenInstance.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    _mockOpenInstance.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
 
     // Nothing left to remove
     Assert.That(_queue.TryRemoveInstance(out instance), Is.False);
@@ -60,33 +60,33 @@ public class RoundRobinLambdaInstanceQueue2Tests
     _mockClosedInstance.SetupGet(i => i.IsOpen).Returns(true);
     _queue.AddInstance(_mockInstance.Object);
     Assert.That(_queue.TryGetConnection(out connection), Is.False);
-    _mockClosedInstance.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Never);
+    _mockClosedInstance.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Never);
     Assert.That(_queue.TryRemoveInstance(out instance), Is.False);
   }
 
   [Test]
   public void TryGetConnection_ShouldReturnFalseIfNoInstances()
   {
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.False);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.False);
   }
 
   [Test]
   public void TryGetConnection_ShouldReturnTrueIfInstanceHasConnection()
   {
     _mockInstance.Setup(i => i.IsOpen).Returns(true);
-    _mockInstance.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
+    _mockInstance.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
     _queue.AddInstance(_mockInstance.Object);
 
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.True);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.True);
   }
 
   [Test]
   public void TryGetConnection_ShouldReturnFalseIfInstanceHasNoConnection()
   {
-    _mockInstance.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
+    _mockInstance.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
     _queue.AddInstance(_mockInstance.Object);
 
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.False);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.False);
   }
 
   [Test]
@@ -100,9 +100,9 @@ public class RoundRobinLambdaInstanceQueue2Tests
     _mockInstanceWithConnection = new Mock<ILambdaInstance>();
 
     _mockInstanceWithoutConnection.Setup(i => i.IsOpen).Returns(true);
-    _mockInstanceWithoutConnection.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
+    _mockInstanceWithoutConnection.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
     _mockInstanceWithConnection.Setup(i => i.IsOpen).Returns(true);
-    _mockInstanceWithConnection.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
+    _mockInstanceWithConnection.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
 
     for (int i = 0; i < 9; i++)
     {
@@ -111,10 +111,10 @@ public class RoundRobinLambdaInstanceQueue2Tests
 
     _queue.AddInstance(_mockInstanceWithConnection.Object);
 
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.True);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.True);
 
-    _mockInstanceWithoutConnection.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(9));
-    _mockInstanceWithConnection.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    _mockInstanceWithoutConnection.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(9));
+    _mockInstanceWithConnection.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
   }
 
   [Test]
@@ -127,51 +127,51 @@ public class RoundRobinLambdaInstanceQueue2Tests
 
     var callCount = 0;
     mockInstance1.Setup(i => i.IsOpen).Returns(true);
-    mockInstance1.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()))
+    mockInstance1.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()))
         .Returns(() => callCount++ == 0 ? false : true);
     mockInstance2.Setup(i => i.IsOpen).Returns(true);
-    mockInstance2.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
+    mockInstance2.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
     mockInstance3.Setup(i => i.IsOpen).Returns(true);
-    mockInstance3.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
+    mockInstance3.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
     mockInstance4.Setup(i => i.IsOpen).Returns(false);
-    mockInstance4.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
+    mockInstance4.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
 
     _queue.AddInstance(mockInstance1.Object);
     _queue.AddInstance(mockInstance2.Object);
     _queue.AddInstance(mockInstance3.Object);
     _queue.AddInstance(mockInstance4.Object);
 
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.True);
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.True);
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
     // This gives the connection on 1st call
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
 
     Assert.That(_queue.TryGetConnection(out connection), Is.True);
     // This gives the connection on the 2nd call
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
 
     Assert.That(_queue.TryGetConnection(out connection), Is.True);
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
     // This gives the connection on the 3rd call
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
 
     Assert.That(_queue.TryGetConnection(out connection), Is.True);
     // This gives the connection on the 4th call
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
 
     Assert.That(_queue.TryGetConnection(out connection), Is.True);
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
     // This gives the connection on the 5th call
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
 
     mockInstance4.Verify(i => i.IsOpen, Times.Exactly(2));
-    mockInstance4.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Never);
+    mockInstance4.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Never);
   }
 }

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/RoundRobinLambdaInstanceQueueTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/RoundRobinLambdaInstanceQueueTests.cs
@@ -35,26 +35,26 @@ public class RoundRobinLambdaInstanceQueueTests
   [Test]
   public void TryGetConnection_ShouldReturnFalseIfNoInstances()
   {
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.False);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.False);
   }
 
   [Test]
   public void TryGetConnection_ShouldReturnTrueIfInstanceHasConnection()
   {
     _mockInstance.Setup(i => i.IsOpen).Returns(true);
-    _mockInstance.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
+    _mockInstance.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
     _queue.AddInstance(_mockInstance.Object);
 
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.True);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.True);
   }
 
   [Test]
   public void TryGetConnection_ShouldReturnFalseIfInstanceHasNoConnection()
   {
-    _mockInstance.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
+    _mockInstance.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
     _queue.AddInstance(_mockInstance.Object);
 
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.False);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.False);
   }
 
   [Test]
@@ -68,9 +68,9 @@ public class RoundRobinLambdaInstanceQueueTests
     _mockInstanceWithConnection = new Mock<ILambdaInstance>();
 
     _mockInstanceWithoutConnection.Setup(i => i.IsOpen).Returns(true);
-    _mockInstanceWithoutConnection.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
+    _mockInstanceWithoutConnection.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
     _mockInstanceWithConnection.Setup(i => i.IsOpen).Returns(true);
-    _mockInstanceWithConnection.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
+    _mockInstanceWithConnection.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
 
     for (int i = 0; i < 9; i++)
     {
@@ -79,10 +79,10 @@ public class RoundRobinLambdaInstanceQueueTests
 
     _queue.AddInstance(_mockInstanceWithConnection.Object);
 
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.True);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.True);
 
-    _mockInstanceWithoutConnection.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(9));
-    _mockInstanceWithConnection.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    _mockInstanceWithoutConnection.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(9));
+    _mockInstanceWithConnection.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
   }
 
   [Test]
@@ -94,45 +94,45 @@ public class RoundRobinLambdaInstanceQueueTests
 
     var callCount = 0;
     mockInstance1.Setup(i => i.IsOpen).Returns(true);
-    mockInstance1.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()))
+    mockInstance1.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()))
         .Returns(() => callCount++ == 0 ? false : true);
     mockInstance2.Setup(i => i.IsOpen).Returns(true);
-    mockInstance2.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
+    mockInstance2.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(false);
     mockInstance3.Setup(i => i.IsOpen).Returns(true);
-    mockInstance3.Setup(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
+    mockInstance3.Setup(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>())).Returns(true);
 
     _queue.AddInstance(mockInstance1.Object);
     _queue.AddInstance(mockInstance2.Object);
     _queue.AddInstance(mockInstance3.Object);
 
-    Assert.That(_queue.TryGetConnection(out LambdaConnection? connection), Is.True);
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    Assert.That(_queue.TryGetConnection(out ILambdaConnection? connection), Is.True);
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
     // This gives the connection on 1st call
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
 
     Assert.That(_queue.TryGetConnection(out connection), Is.True);
     // This gives the connection on the 2nd call
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Once);
 
     Assert.That(_queue.TryGetConnection(out connection), Is.True);
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
     // This gives the connection on the 3rd call
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
 
     Assert.That(_queue.TryGetConnection(out connection), Is.True);
     // This gives the connection on the 4th call
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(2));
 
     Assert.That(_queue.TryGetConnection(out connection), Is.True);
-    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
-    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
+    mockInstance1.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
+    mockInstance2.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
     // This gives the connection on the 5th call
-    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<LambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
+    mockInstance3.Verify(i => i.TryGetConnection(out It.Ref<ILambdaConnection?>.IsAny, It.IsAny<bool>()), Times.Exactly(3));
   }
 }


### PR DESCRIPTION
- Add tests and interfaces for basically everything
- Add `ILambdaConnection` interface
- Add `IMetricsRegistry` interface
- Add `ChunkedController.Close` tests
- Add `ChunkedController.Post` tests
- Mock `IMetricsRegistry` for existing tests
- Fix most compiler warnings

## After - 60% Coverage for Router

<img width="1547" alt="image" src="https://github.com/pwrdrvr/lambda-dispatch/assets/5617868/bae0f710-88ed-490a-b41c-cecfc0a9e8e8">
