### PR TITLE
Issue 163 - Report coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Install Coverlet and ReportGenerator
         run: |
-          dotnet tool install --global coverlet.console
           dotnet tool install --global dotnet-reportgenerator-globaltool
 
       - name: Run DotNet Tests with coverage
@@ -38,7 +37,7 @@ jobs:
         uses: mikepenz/action-junit-report@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: "test/coverage/html_report/index.htm"
+          report_paths: "test/coverage/html_report/index.html"
 
   rust-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,25 +21,17 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: Install Coverlet and ReportGenerator
-        run: |
-          dotnet tool install --global dotnet-reportgenerator-globaltool
-
-      - name: Run DotNet Tests with coverage
-        run: |
-          dotnet test --collect:"XPlat Code Coverage"
-
-      - name: Generate Coverage Report
-        if: success() || failure()
-        run: |
-          reportgenerator "-reports:test/coverage/projects/PwrDrvr.LambdaDispatch.Router.Tests/coverage.opencover.xml" "-targetdir:test/coverage/html_report" -reporttypes:Html
-
-      - name: Publish Coverage Report
-        if: success() || failure()
-        uses: mikepenz/action-junit-report@v4
+      - name: unit tests for Contoso Service Layer
+        uses: zyborg/dotnet-tests-report@v1
         with:
+          project_path: test/PwrDrvr.LambdaDispatch.Router.Tests/
+          report_name: lambda_dispatch_router_tests
+          report_title: Lambda Dispatch Router Tests
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: "test/coverage/html_report/index.html"
+          set_check_status_from_test_outcome: true
+          # gist_name: contoso_service_tests.md
+          # gist_badge_label: "Contoso Service: %Counters_passed%/%Counters_total%"
+          # gist_token: ${{ secrets.GIST_TOKEN }}
 
   rust-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,10 +30,12 @@ jobs:
           dotnet test --collect:"XPlat Code Coverage"
 
       - name: Generate Coverage Report
+        if: success() || failure()
         run: |
           reportgenerator "-reports:test/coverage/projects/PwrDrvr.LambdaDispatch.Router.Tests/coverage.opencover.xml" "-targetdir:test/coverage/html_report" -reporttypes:Html
 
       - name: Publish Coverage Report
+        if: success() || failure()
         uses: mikepenz/action-junit-report@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,13 +11,34 @@ on:
 jobs:
   dotnet-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run DotNet Tests
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Install Coverlet and ReportGenerator
         run: |
-          dotnet test
+          dotnet tool install --global coverlet.console
+          dotnet tool install --global dotnet-reportgenerator-globaltool
+
+      - name: Run DotNet Tests with coverage
+        run: |
+          coverlet ./test/Project.Tests --target "dotnet" --targetargs "test ./test/Project.Tests --no-restore" --format opencover
+
+      - name: Generate Coverage Report
+        run: |
+          reportgenerator "-reports:./coverage.opencover.xml" "-targetdir:./coverage" -reporttypes:Html
+
+      - name: Publish Coverage Report
+        uses: mikepenz/action-junit-report@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: "coverage/index.htm"
 
   rust-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,17 +28,17 @@ jobs:
 
       - name: Run DotNet Tests with coverage
         run: |
-          coverlet ./test/Project.Tests --target "dotnet" --targetargs "test ./test/Project.Tests --no-restore" --format opencover
+          dotnet test --collect:"XPlat Code Coverage"
 
       - name: Generate Coverage Report
         run: |
-          reportgenerator "-reports:./coverage.opencover.xml" "-targetdir:./coverage" -reporttypes:Html
+          reportgenerator "-reports:test/coverage/projects/PwrDrvr.LambdaDispatch.Router.Tests/coverage.opencover.xml" "-targetdir:test/coverage/html_report" -reporttypes:Html
 
       - name: Publish Coverage Report
         uses: mikepenz/action-junit-report@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: "coverage/index.htm"
+          report_paths: "test/coverage/html_report/index.htm"
 
   rust-tests:
     runs-on: ubuntu-latest

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
@@ -36,6 +36,7 @@ public class MetadataServiceTests
     var metadataService = new MetadataService(config: configWithRouterCallbackHost);
 
     Assert.That(metadataService.NetworkIP, Is.EqualTo("192.168.1.1"));
+    Assert.That(true, Is.False)
   }
 
   [Test]

--- a/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
+++ b/test/PwrDrvr.LambdaDispatch.Router.Tests/MetadataServiceTests.cs
@@ -36,7 +36,7 @@ public class MetadataServiceTests
     var metadataService = new MetadataService(config: configWithRouterCallbackHost);
 
     Assert.That(metadataService.NetworkIP, Is.EqualTo("192.168.1.1"));
-    Assert.That(true, Is.False)
+    Assert.That(true, Is.False);
   }
 
   [Test]


### PR DESCRIPTION
- Fixes #163 

## Generating Local Coverage Report

```sh
dotnet test --collect:"XPlat Code Coverage" && \
reportgenerator "-reports:test/coverage/projects/PwrDrvr.LambdaDispatch.Router.Tests/coverage.opencover.xml" \
  "-targetdir:test/coverage/html_report" \
  -reporttypes:Html
```

## Location of Coverage Report

`test/coverage/html_report/index.html`