### PR TITLE
Issue 182 - Error handling, propagation, etc.

### DIFF
--- a/DEVELOPMENT-CURRENT-COMMANDS.md
+++ b/DEVELOPMENT-CURRENT-COMMANDS.md
@@ -1,8 +1,13 @@
 # stress
 
 curl -v http://localhost:5001/ping
+
 TOKIO_WORKER_THREADS=1 oha -c 20 -z 60s http://127.0.0.1:5001/ping
+
+TOKIO_WORKER_THREADS=1 oha -c 20 -z 60s -D target/release/extension -T application/octet-stream -m POST http://127.0.0.1:5001/echo
+
 k6 run k6/ping-dispatch-local.js
+
 curl -X POST -H "Content-Type: text/markdown" --data-binary @README.md http://localhost:5001/echo --compressed -o README2.md -v
 
 # node

--- a/extension/src/app_request.rs
+++ b/extension/src/app_request.rs
@@ -116,10 +116,6 @@ mod tests {
           async move {
             // Increment the request count
             request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            println!(
-              "Request count: {}",
-              request_count.load(std::sync::atomic::Ordering::SeqCst)
-            );
 
             if request_count.load(std::sync::atomic::Ordering::SeqCst) == 1 {
               let req =
@@ -235,10 +231,6 @@ mod tests {
             async move {
               // Increment the request count
               request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-              println!(
-                "Request count: {}",
-                request_count.load(std::sync::atomic::Ordering::SeqCst)
-              );
 
               if request_count.load(std::sync::atomic::Ordering::SeqCst) == 1 {
                 let req =
@@ -357,10 +349,6 @@ mod tests {
           async move {
             // Increment the request count
             request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            println!(
-              "Request count: {}",
-              request_count.load(std::sync::atomic::Ordering::SeqCst)
-            );
 
             // Create a channel for the stream
             let (mut tx, rx) = tokio::io::duplex(65_536);
@@ -485,10 +473,6 @@ mod tests {
           async move {
             // Increment the request count
             request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            println!(
-              "Request count: {}",
-              request_count.load(std::sync::atomic::Ordering::SeqCst)
-            );
 
             // Create a channel for the stream
             let (mut tx, rx) = tokio::io::duplex(65_536);

--- a/extension/src/app_start.rs
+++ b/extension/src/app_start.rs
@@ -32,11 +32,6 @@ async fn create_connection(
     }
     Ok(Err(err)) => {
       // Connection error
-      log::error!(
-        "Health check - Contained App TcpStream::connect error: {}, endpoint: {}",
-        err,
-        healthcheck_addr
-      );
       return Err(anyhow::anyhow!(
         "Health check - TcpStream::connect error: {}",
         err
@@ -44,11 +39,6 @@ async fn create_connection(
     }
     Err(err) => {
       // Timeout
-      log::error!(
-        "Health check - Contained App TcpStream::connect timed out: {}, endpoint: {}",
-        err,
-        healthcheck_addr
-      );
       return Err(anyhow::anyhow!(
         "Health check - TcpStream::connect timed out: {}",
         err
@@ -144,8 +134,7 @@ pub async fn health_check_contained_app(
             }
           }));
         }
-        Err(e) => {
-          log::error!("Failed to create connection: {}", e);
+        Err(_) => {
           continue;
         }
       }

--- a/extension/src/lambda_request.rs
+++ b/extension/src/lambda_request.rs
@@ -154,7 +154,11 @@ impl LambdaRequest {
 
         for result in results {
           match result {
-            Ok(_) => {}
+            Ok(result) => {
+              if let Some(result) = result {
+                exit_reason = exit_reason.worse(result.into());
+              }
+            }
             Err(err) => {
               log::error!(
                 "LambdaId: {} - run - Error in channel task: {:?}",
@@ -194,8 +198,8 @@ impl LambdaRequest {
 
         // If the ping task knows why we exited, use that reason
         if let Some(ping_result) = result {
-          if let Some(exit_reason_value) = ping_result.into() {
-            exit_reason = exit_reason.worse(exit_reason_value);
+          if let Some(ping_result) = ping_result.into() {
+            exit_reason = exit_reason.worse(ping_result);
           }
         }
       }

--- a/extension/src/lambda_request.rs
+++ b/extension/src/lambda_request.rs
@@ -9,17 +9,37 @@ use tokio::{
 };
 use tokio_rustls::client::TlsStream;
 
-use crate::connect_to_router;
 use crate::endpoint::Endpoint;
 use crate::ping;
 use crate::prelude::*;
 use crate::router_channel::RouterChannel;
 use crate::time::current_time_millis;
+use crate::{connect_to_router, messages};
 
 // Define a Stream trait that both TlsStream and TcpStream implement
 pub trait Stream: AsyncRead + AsyncWrite + Send {}
 impl Stream for TlsStream<TcpStream> {}
 impl Stream for TcpStream {}
+
+#[derive(Debug, PartialEq)]
+pub enum LambdaRequestError {
+  RouterUnreachable,
+  SendRequestError,
+}
+
+impl std::fmt::Display for LambdaRequestError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      LambdaRequestError::RouterUnreachable => {
+        write!(f, "Failed to establish connection to router")
+      }
+      LambdaRequestError::SendRequestError => write!(f, "Failed to send request"),
+      // Other error variants...
+    }
+  }
+}
+
+impl std::error::Error for LambdaRequestError {}
 
 /// A `LambdaRequest` handles connecting back to the router, picking up requests, sending ping
 /// requests to the router, and sending the requests to the contained app When an invoke completes
@@ -38,7 +58,8 @@ pub struct LambdaRequest {
   last_active: Arc<AtomicU64>,
   rng: rand::rngs::StdRng,
   requests_in_flight: Arc<AtomicUsize>,
-  count: Arc<AtomicUsize>,
+  pub count: Arc<AtomicUsize>,
+  start_time: u64,
 }
 impl LambdaRequest {
   /// Create a new `LambdaRequest` task with a specified deadline.
@@ -70,19 +91,22 @@ impl LambdaRequest {
       last_active: Arc::new(AtomicU64::new(0)),
       rng: rand::rngs::StdRng::from_entropy(),
       requests_in_flight: Arc::new(AtomicUsize::new(0)),
+      start_time: current_time_millis(),
     }
   }
 
   /// Executes a task with a specified deadline.
-  pub async fn start(&mut self) -> Result<(), Error> {
-    let start_time = current_time_millis();
-
-    let sender = connect_to_router::connect_to_router(
+  pub async fn start(&mut self) -> Result<messages::ExitReason, Error> {
+    let sender = match connect_to_router::connect_to_router(
       self.router_endpoint.clone(),
       Arc::clone(&self.pool_id),
       Arc::clone(&self.lambda_id),
     )
-    .await?;
+    .await
+    {
+      Ok(sender) => sender,
+      Err(_) => return Err(LambdaRequestError::RouterUnreachable.into()),
+    };
 
     // Send the ping requests in background
     let ping_task = tokio::task::spawn(ping::send_ping_requests(
@@ -99,7 +123,7 @@ impl LambdaRequest {
     ));
 
     // Startup the request channels
-    let futures = (0..self.channel_count)
+    let channel_futures = (0..self.channel_count)
       .map(|channel_number| {
         let last_active = Arc::clone(&self.last_active);
         // Create a JoinHandle and implicitly return it to be collected in the vector
@@ -123,13 +147,18 @@ impl LambdaRequest {
       })
       .collect::<Vec<_>>();
 
+    let mut exit_reason = messages::ExitReason::RouterGoaway;
+
     tokio::select! {
-        result = futures::future::try_join_all(futures) => {
+        result = futures::future::try_join_all(channel_futures) => {
             match result {
                 Ok(_) => {
                   // All tasks completed successfully
+
+                  // TODO: Check the channel exit reasons (most likely a goaway)
                 }
                 Err(_) => {
+                  // TODO: Capture the channel exit error and return the worst one we find
                   panic!("LambdaId: {} - run - Error in futures::future::try_join_all", self.lambda_id);
                 }
             }
@@ -138,22 +167,286 @@ impl LambdaRequest {
 
     // Wait for the ping loop to exit
     self.cancel_token.cancel();
-    ping_task.await?;
+    match ping_task.await {
+      Ok(result) => {
+        // Ping task completed successfully
 
-    // Print final stats
-    let elapsed = current_time_millis() - start_time;
-    let rps = format!(
-      "{:.1}",
-      self.count.load(Ordering::Acquire) as f64 / (elapsed as f64 / 1000.0)
-    );
-    log::info!(
-      "LambdaId: {}, Requests: {}, Elapsed: {} ms, RPS: {} - Returning from run",
-      self.lambda_id,
-      self.count.load(Ordering::Acquire),
-      elapsed,
-      rps
+        // If the ping task knows why we exited, use that reason
+        if let Some(ping_result) = result {
+          if let Some(exit_reason_value) = ping_result.into() {
+            exit_reason = exit_reason.worse(exit_reason_value);
+          }
+        }
+      }
+      Err(e) => {
+        log::error!(
+          "LambdaId: {} - run - Error in ping task: {:?}",
+          self.lambda_id,
+          e
+        );
+        // We'll lump this in as a generic router connection error
+        return Err(LambdaRequestError::RouterUnreachable.into());
+      }
+    }
+
+    Ok(exit_reason)
+  }
+
+  pub fn elapsed(&self) -> u64 {
+    current_time_millis() - self.start_time
+  }
+
+  pub fn rps(&self) -> f64 {
+    self.count.load(Ordering::Acquire) as f64 / (self.elapsed() as f64 / 1000.0)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  use crate::test_http2_server::test_http2_server::run_http2_app;
+
+  use axum::response::Response;
+  use axum::routing::get;
+  use axum::{extract::Path, routing::post, Router};
+  use axum_extra::body::AsyncReadBody;
+  use futures::stream::StreamExt;
+  use httpmock::Method::GET;
+  use httpmock::MockServer;
+  use hyper::StatusCode;
+  use tokio::io::AsyncWriteExt;
+
+  #[tokio::test]
+  async fn test_lambda_request_router_blackhole() {
+    let mut lambda_request = LambdaRequest::new(
+      Endpoint::new(crate::endpoint::Scheme::Http, "192.0.2.0", 12345),
+      false,
+      "pool_id".into(),
+      "lambda_id".into(),
+      1,
+      Endpoint::new(crate::endpoint::Scheme::Http, "192.0.2.0", 54321),
+      current_time_millis() + 60 * 1000,
     );
 
-    Ok(())
+    // Act
+    let start = std::time::Instant::now();
+    let result = lambda_request.start().await;
+    let duration = std::time::Instant::now().duration_since(start);
+
+    // Assert
+    if let Err(err) = &result {
+      assert!(
+        err.downcast_ref::<LambdaRequestError>().is_some(),
+        "Expected LambdaRequestError"
+      );
+      if let Some(lambda_err) = err.downcast_ref::<LambdaRequestError>() {
+        assert_eq!(
+          *lambda_err,
+          LambdaRequestError::RouterUnreachable,
+          "Expected LambdaRequestError::RouterUnreachable"
+        );
+      } else {
+        assert!(false, "Expected LambdaRequestError");
+      }
+    } else {
+      assert!(false, "Expected an error result");
+    }
+    assert!(
+      duration > std::time::Duration::from_secs(5),
+      "Connection should take at least 5 seconds"
+    );
+    assert!(
+      duration <= std::time::Duration::from_secs(6),
+      "Connection should take at most 6 seconds"
+    );
+  }
+
+  #[tokio::test]
+  async fn test_lambda_request_router_connects_ping_panics() {
+    // Start router server
+    let (release_request_tx, release_request_rx) = tokio::sync::mpsc::channel::<()>(1);
+    let release_request_rx = Arc::new(tokio::sync::Mutex::new(release_request_rx));
+    // Use an arc int to count how many times the request endpoint was called
+    let request_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let request_count_clone = Arc::clone(&request_count);
+    let ping_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ping_count_clone = Arc::clone(&ping_count);
+    let close_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let close_count_clone = Arc::clone(&close_count);
+    let app = Router::new()
+      .route(
+        "/api/chunked/request/:lambda_id/:channel_id",
+        post(
+          move |Path((_lambda_id, _channel_id)): Path<(String, String)>,
+              request: axum::extract::Request| {
+          let request_count = Arc::clone(&request_count_clone);
+          let release_request_rx = Arc::clone(&release_request_rx);
+
+          async move {
+            // Spawn a task to write to the stream
+            tokio::spawn(async move {
+              let parts = request.into_parts();
+
+              parts
+                .1
+                .into_data_stream()
+                .for_each(|chunk| async {
+                  let chunk = chunk.unwrap();
+                  println!("Chunk: {:?}", chunk);
+                })
+                .await;
+
+              println!(
+                "Router Channel - Request body (for contained app response) finished writing"
+              );
+            });
+
+            // Increment the request count
+            request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            println!(
+              "Request count: {}",
+              request_count.load(std::sync::atomic::Ordering::SeqCst)
+            );
+
+            // Bail after 1st request
+            if request_count.load(std::sync::atomic::Ordering::SeqCst) > 1 {
+              let body = AsyncReadBody::new(tokio::io::empty());
+              let response = Response::builder()
+                .status(StatusCode::CONFLICT)
+                .body(body)
+                .unwrap();
+
+              return response;
+            }
+
+            // Create a channel for the stream
+            let (mut tx, rx) = tokio::io::duplex(65_536);
+
+            // Spawn a task to write to the stream
+            tokio::spawn(async move {
+              //
+              // Tell extension to GOAWAY
+              //
+              let data = b"GET /bananas HTTP/1.1\r\nHost: localhost\r\nTest-Header: foo\r\n";
+              tx.write_all(data).await.unwrap();
+
+              // Write the rest of the headers
+              let data = b"Test-Headers: bar\r\nTest-Headerss: baz\r\nAccept-Encoding: gzip\r\n\r\nHELLO WORLD";
+              tx.write_all(data).await.unwrap();
+
+              // Wait for the release
+              release_request_rx.lock().await.recv().await;
+
+              // Close the body stream
+              tx.shutdown().await.unwrap();
+
+              println!(
+                "Router Channel - Response body (for contained app request) finished reading"
+              );
+            });
+
+            let body = AsyncReadBody::new(rx);
+
+            let response = Response::builder()
+              .header("content-type", "application/octet-stream")
+              .body(body)
+              .unwrap();
+
+            response
+          }
+        },
+        ),
+      )
+      .route(
+        "/api/chunked/ping/:lambda_id",
+        get(|Path(lambda_id): Path<String>| async move {
+          let ping_count = Arc::clone(&ping_count_clone);
+          // Increment
+          ping_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+          // Panic so the stream closes
+          panic!("Ping! LambdaID: {}", lambda_id);
+        }),
+      )
+      .route(
+        "/api/chunked/close/:lambda_id",
+        get(|Path(lambda_id): Path<String>| async move {
+          let close_count = Arc::clone(&close_count_clone);
+          // Increment
+          close_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+          log::info!("Close! LambdaID: {}", lambda_id);
+          format!("Close! LambdaID: {}", lambda_id)
+        }),
+      );
+
+    let mock_router_server = run_http2_app(app);
+    let mock_router_endpoint = Endpoint::new(
+      crate::endpoint::Scheme::Http,
+      "127.0.0.1",
+      mock_router_server.addr.port(),
+    );
+
+    // Start app server
+    let mock_app_server = MockServer::start();
+    let mock_app_healthcheck = mock_app_server.mock(|when, then| {
+      when.method(GET).path("/health");
+      then.status(200).body("OK");
+    });
+    let mock_app_bananas = mock_app_server.mock(|when, then| {
+      when.method(GET).path("/bananas");
+      then
+        .status(200)
+        .header("Content-Type", "text/plain")
+        .header("Connection", "close")
+        .header("Keep-Alive", "timeout=5")
+        .body("Bananas");
+    });
+    let app_endpoint: Endpoint = mock_app_server.base_url().parse().unwrap();
+
+    let mut lambda_request = LambdaRequest::new(
+      app_endpoint,
+      false,
+      "pool_id".into(),
+      "lambda_id".into(),
+      1,
+      mock_router_endpoint,
+      current_time_millis() + 60 * 1000,
+    );
+
+    // Blow up the mock router server
+    // Release the request after a few seconds
+    tokio::spawn(async move {
+      tokio::time::sleep(tokio::time::Duration::from_secs(6)).await;
+      release_request_tx.send(()).await.unwrap();
+    });
+
+    // Act
+    let start = std::time::Instant::now();
+    let result = lambda_request.start().await;
+    let duration = std::time::Instant::now().duration_since(start);
+
+    // Assert
+    match result {
+      Ok(exit_reason) => {
+        assert_eq!(exit_reason, messages::ExitReason::RouterConnectionError);
+      }
+      Err(err) => {
+        assert!(false, "Expected Ok with ExitReason, got Err: {:?}", err);
+      }
+    }
+    assert!(
+      duration > std::time::Duration::from_secs(6),
+      "Connection should take at least 6 seconds"
+    );
+    assert!(
+      duration <= std::time::Duration::from_secs(7),
+      "Connection should take at most 7 seconds"
+    );
+
+    // Healthcheck not called
+    mock_app_healthcheck.assert_hits(0);
+    // Bananas called once
+    mock_app_bananas.assert_hits(1);
   }
 }

--- a/extension/src/lambda_request.rs
+++ b/extension/src/lambda_request.rs
@@ -136,7 +136,7 @@ impl LambdaRequest {
       })
       .collect::<Vec<_>>();
 
-    let mut exit_reason = messages::ExitReason::RouterGoaway;
+    let mut exit_reason = messages::ExitReason::RouterGoAway;
 
     // `try_join_all` says all futures will be immediately canceled if one of them returns an error
     // However, this "cancelation" is cooperative and has to be checked by the tasks themselves

--- a/extension/src/lambda_request.rs
+++ b/extension/src/lambda_request.rs
@@ -10,6 +10,7 @@ use tokio::{
 use tokio_rustls::client::TlsStream;
 
 use crate::endpoint::Endpoint;
+use crate::lambda_request_error::LambdaRequestError;
 use crate::ping;
 use crate::prelude::*;
 use crate::router_channel::RouterChannel;
@@ -20,26 +21,6 @@ use crate::{connect_to_router, messages};
 pub trait Stream: AsyncRead + AsyncWrite + Send {}
 impl Stream for TlsStream<TcpStream> {}
 impl Stream for TcpStream {}
-
-#[derive(Debug, PartialEq)]
-pub enum LambdaRequestError {
-  RouterUnreachable,
-  SendRequestError,
-}
-
-impl std::fmt::Display for LambdaRequestError {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match self {
-      LambdaRequestError::RouterUnreachable => {
-        write!(f, "Failed to establish connection to router")
-      }
-      LambdaRequestError::SendRequestError => write!(f, "Failed to send request"),
-      // Other error variants...
-    }
-  }
-}
-
-impl std::error::Error for LambdaRequestError {}
 
 /// A `LambdaRequest` handles connecting back to the router, picking up requests, sending ping
 /// requests to the router, and sending the requests to the contained app When an invoke completes

--- a/extension/src/lambda_request.rs
+++ b/extension/src/lambda_request.rs
@@ -131,11 +131,6 @@ impl LambdaRequest {
           // Tell the other channels to stop
           goaway_received.store(true, Ordering::Release);
 
-          println!(
-            "Channel {} finished with result: {:?}",
-            channel_number, result
-          );
-
           result
         })
       })
@@ -310,22 +305,14 @@ mod tests {
                 .1
                 .into_data_stream()
                 .for_each(|chunk| async {
-                  let chunk = chunk.unwrap();
-                  println!("Chunk: {:?}", chunk);
+                  let _chunk = chunk.unwrap();
+                  // println!("Chunk: {:?}", chunk);
                 })
                 .await;
-
-              println!(
-                "Router Channel - Request body (for contained app response) finished writing"
-              );
             });
 
             // Increment the request count
             request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            println!(
-              "Request count: {}",
-              request_count.load(std::sync::atomic::Ordering::SeqCst)
-            );
 
             // Bail after 1st request
             if request_count.load(std::sync::atomic::Ordering::SeqCst) > 1 {
@@ -358,10 +345,6 @@ mod tests {
 
               // Close the body stream
               tx.shutdown().await.unwrap();
-
-              println!(
-                "Router Channel - Response body (for contained app request) finished reading"
-              );
             });
 
             let body = AsyncReadBody::new(rx);

--- a/extension/src/lambda_request_error.rs
+++ b/extension/src/lambda_request_error.rs
@@ -1,0 +1,62 @@
+use crate::messages::ExitReason;
+
+#[derive(Debug, PartialEq)]
+pub enum LambdaRequestError {
+  RouterUnreachable,
+  SendRequestError,
+}
+
+impl std::fmt::Display for LambdaRequestError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      LambdaRequestError::RouterUnreachable => {
+        write!(f, "Failed to establish connection to router")
+      }
+      LambdaRequestError::SendRequestError => write!(f, "Failed to send request"),
+    }
+  }
+}
+
+impl std::error::Error for LambdaRequestError {}
+
+impl From<LambdaRequestError> for ExitReason {
+  fn from(error: LambdaRequestError) -> Self {
+    ExitReason::from(&error)
+  }
+}
+
+impl From<&LambdaRequestError> for ExitReason {
+  fn from(error: &LambdaRequestError) -> Self {
+    match *error {
+      LambdaRequestError::RouterUnreachable => ExitReason::RouterUnreachable,
+      LambdaRequestError::SendRequestError => ExitReason::RouterConnectionError,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_from_lambda_request_error() {
+    let error = LambdaRequestError::RouterUnreachable;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::RouterUnreachable);
+
+    let error = LambdaRequestError::SendRequestError;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::RouterConnectionError);
+  }
+
+  #[test]
+  fn test_from_lambda_request_error_ref() {
+    let error = &LambdaRequestError::RouterUnreachable;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::RouterUnreachable);
+
+    let error = &LambdaRequestError::SendRequestError;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::RouterConnectionError);
+  }
+}

--- a/extension/src/lambda_request_error.rs
+++ b/extension/src/lambda_request_error.rs
@@ -3,7 +3,10 @@ use crate::messages::ExitReason;
 #[derive(Debug, PartialEq)]
 pub enum LambdaRequestError {
   RouterUnreachable,
-  SendRequestError,
+  RouterConnectionError,
+  AppConnectionUnreachable,
+  AppConnectionError,
+  ChannelErrorOther,
 }
 
 impl std::fmt::Display for LambdaRequestError {
@@ -12,7 +15,24 @@ impl std::fmt::Display for LambdaRequestError {
       LambdaRequestError::RouterUnreachable => {
         write!(f, "Failed to establish connection to router")
       }
-      LambdaRequestError::SendRequestError => write!(f, "Failed to send request"),
+      LambdaRequestError::RouterConnectionError => {
+        write!(
+          f,
+          "Established router connection failed while reading or writing"
+        )
+      }
+      LambdaRequestError::AppConnectionUnreachable => {
+        write!(f, "Failed to establish connection to app")
+      }
+      LambdaRequestError::AppConnectionError => {
+        write!(
+          f,
+          "Established app connection failed while reading or writing"
+        )
+      }
+      LambdaRequestError::ChannelErrorOther => {
+        write!(f, "Channel error other than connection error")
+      }
     }
   }
 }
@@ -29,8 +49,50 @@ impl From<&LambdaRequestError> for ExitReason {
   fn from(error: &LambdaRequestError) -> Self {
     match *error {
       LambdaRequestError::RouterUnreachable => ExitReason::RouterUnreachable,
-      LambdaRequestError::SendRequestError => ExitReason::RouterConnectionError,
+      LambdaRequestError::RouterConnectionError => ExitReason::RouterConnectionError,
+      LambdaRequestError::AppConnectionUnreachable => ExitReason::AppConnectionError,
+      LambdaRequestError::AppConnectionError => ExitReason::AppConnectionError,
+      LambdaRequestError::ChannelErrorOther => ExitReason::ChannelErrorOther,
     }
+  }
+}
+
+impl LambdaRequestError {
+  pub fn worse(self, other: Self) -> Self {
+    use LambdaRequestError::*;
+
+    let ordered_reasons = [
+      RouterUnreachable,
+      RouterConnectionError,
+      AppConnectionUnreachable,
+      AppConnectionError,
+      ChannelErrorOther,
+    ];
+
+    for reason in ordered_reasons {
+      if self == reason || other == reason {
+        return reason;
+      }
+    }
+
+    self // If no match is found, return the current value
+  }
+
+  // This function will cause a compile-time error if a new variant is added to the enum
+  // but not added to the match expression.
+  #[allow(dead_code)]
+  fn ensure_all_variants_handled(variant: Self) {
+    use LambdaRequestError::*;
+
+    match variant {
+      // HEY - If you add here you need to add to the `worse` function array above
+      RouterUnreachable => {}
+      RouterConnectionError => {}
+      AppConnectionUnreachable => {}
+      AppConnectionError => {}
+      ChannelErrorOther => {}
+    }
+    // HEY - If you add here you need to add to the `worse` function array above
   }
 }
 
@@ -44,9 +106,21 @@ mod tests {
     let exit_reason: ExitReason = error.into();
     assert_eq!(exit_reason, ExitReason::RouterUnreachable);
 
-    let error = LambdaRequestError::SendRequestError;
+    let error = LambdaRequestError::RouterConnectionError;
     let exit_reason: ExitReason = error.into();
     assert_eq!(exit_reason, ExitReason::RouterConnectionError);
+
+    let error = LambdaRequestError::AppConnectionUnreachable;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::AppConnectionError);
+
+    let error = LambdaRequestError::AppConnectionError;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::AppConnectionError);
+
+    let error = LambdaRequestError::ChannelErrorOther;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::ChannelErrorOther);
   }
 
   #[test]
@@ -55,8 +129,40 @@ mod tests {
     let exit_reason: ExitReason = error.into();
     assert_eq!(exit_reason, ExitReason::RouterUnreachable);
 
-    let error = &LambdaRequestError::SendRequestError;
+    let error = &LambdaRequestError::RouterConnectionError;
     let exit_reason: ExitReason = error.into();
     assert_eq!(exit_reason, ExitReason::RouterConnectionError);
+
+    let error = &LambdaRequestError::AppConnectionUnreachable;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::AppConnectionError);
+
+    let error = &LambdaRequestError::AppConnectionError;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::AppConnectionError);
+
+    let error = &LambdaRequestError::ChannelErrorOther;
+    let exit_reason: ExitReason = error.into();
+    assert_eq!(exit_reason, ExitReason::ChannelErrorOther);
+  }
+
+  #[test]
+  fn test_worse() {
+    use LambdaRequestError::*;
+
+    // Test that RouterUnreachable is considered worse than AppConnectionError
+    let error1 = RouterUnreachable;
+    let error2 = AppConnectionError;
+    assert_eq!(error1.worse(error2), RouterUnreachable);
+
+    // Test that AppConnectionError is considered worse than ChannelErrorOther
+    let error1 = AppConnectionError;
+    let error2 = ChannelErrorOther;
+    assert_eq!(error1.worse(error2), AppConnectionError);
+
+    // Test that when both errors are the same, that error is returned
+    let error1 = ChannelErrorOther;
+    let error2 = ChannelErrorOther;
+    assert_eq!(error1.worse(error2), ChannelErrorOther);
   }
 }

--- a/extension/src/lambda_service.rs
+++ b/extension/src/lambda_service.rs
@@ -1054,8 +1054,9 @@ mod tests {
       }
     }
     assert!(
-      duration <= std::time::Duration::from_secs(2),
-      "Connection should take at most 2 seconds"
+      duration <= std::time::Duration::from_secs(3),
+      "Test should take at most 3 seconds, took: {:.1}",
+      duration.as_secs_f64()
     );
 
     // Healthcheck not called

--- a/extension/src/lambda_service.rs
+++ b/extension/src/lambda_service.rs
@@ -218,7 +218,7 @@ impl LambdaService {
 
     // Print final stats
     log::info!(
-      "LambdaId: {}, Requests: {}, Elapsed: {} ms, RPS: {} - Returning from run",
+      "LambdaId: {}, Requests: {}, Elapsed: {} ms, RPS: {:.1} - Returning from run",
       lambda_id,
       lambda_request.count.load(Ordering::Acquire),
       lambda_request.elapsed(),
@@ -1061,7 +1061,6 @@ mod tests {
   }
 
   #[tokio::test]
-  #[ignore = "Issue-178 - This test fails because 1 channel exiting does not cause the other channels to exit and because there is no propagation of the error"]
   async fn test_lambda_request_router_connects_channel_request_panics() {
     // Start router server
     let mock_router_server = test_mock_router::test_mock_router::setup_router(
@@ -1164,7 +1163,6 @@ mod tests {
   }
 
   #[tokio::test]
-  #[ignore = "Issue-178 - This test fails because 1 channel exiting does not cause the other channels to exit and because there is no propagation of the error"]
   async fn test_lambda_request_router_connects_channel_response_panics() {
     // Start router server
     let mock_router_server = test_mock_router::test_mock_router::setup_router(

--- a/extension/src/lambda_service.rs
+++ b/extension/src/lambda_service.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use std::{pin::Pin, sync::Arc};
 
 use futures::Future;
@@ -161,18 +162,20 @@ impl LambdaService {
     }
     // check if env var is set to force deadline for testing
     if let Some(force_deadline_secs) = self.options.force_deadline_secs {
-      log::warn!(
-        "Forcing deadline to {} seconds",
-        force_deadline_secs.as_secs()
-      );
-      deadline_ms = current_time_millis() + force_deadline_secs.as_millis() as u64;
+      if force_deadline_secs > Duration::from_secs(0) {
+        log::warn!(
+          "Forcing deadline to {} seconds",
+          force_deadline_secs.as_secs()
+        );
+        deadline_ms = current_time_millis() + force_deadline_secs.as_millis() as u64;
+      }
     }
 
     // run until we get a GoAway or deadline is about to be reached
     let mut lambda_request = LambdaRequest::new(
       app_endpoint,
       self.options.compression,
-      pool_id,
+      Arc::clone(&pool_id),
       Arc::clone(&lambda_id),
       channel_count,
       router_endpoint,
@@ -182,8 +185,29 @@ impl LambdaService {
     //
     // This is the main loop that runs until the deadline is about to be reached
     //
-    lambda_request.start().await?;
-    // TODO: Don't just return an error here (the ?), return a response that indicates the router should backoff
+    let result = lambda_request.start().await;
+    match result {
+      Ok(exit_reason) => {
+        println!(
+          "PoolId: {}, LambdaId: {} - Lambda request completed, exit reason: {:?}",
+          pool_id, lambda_id, exit_reason
+        );
+
+        resp.exit_reason = exit_reason;
+      }
+      Err(e) => {
+        log::error!(
+          "PoolId: {}, LambdaId: {} - Lambda request failed: {}",
+          pool_id,
+          lambda_id,
+          e
+        );
+
+        // Lump this in as a RouterConnectionError too?
+        // TODO: This might be a case where we want to exit
+        resp.exit_reason = ExitReason::RouterConnectionError;
+      }
+    }
 
     // Print final stats
     log::info!(
@@ -196,7 +220,6 @@ impl LambdaService {
 
     resp.invoke_duration = current_time_millis() - start_time;
     resp.request_count = lambda_request.count.load(Ordering::Acquire) as u64;
-    resp.exit_reason = ExitReason::RouterGoaway;
     Ok(resp)
   }
 }
@@ -231,14 +254,19 @@ impl Service<LambdaEvent<WaiterRequest>> for LambdaService {
 mod tests {
   use super::*;
 
-  use crate::test_http2_server::test_http2_server::run_http2_app;
+  use crate::{messages, test_http2_server::test_http2_server::run_http2_app};
   use axum::{
     extract::Path,
+    response::Response,
     routing::{get, post},
     Router,
   };
+  use axum_extra::body::AsyncReadBody;
+  use futures::stream::StreamExt;
   use futures::task::noop_waker;
   use httpmock::{Method::GET, MockServer};
+  use hyper::StatusCode;
+  use tokio::io::AsyncWriteExt;
   use tokio_test::{assert_err, assert_ok};
 
   #[tokio::test]
@@ -493,6 +521,7 @@ mod tests {
   async fn test_lambda_service_fetch_response_local_env_stale_request_reject() {
     // If you want to view logs during a test, uncomment this
     // let _ = env_logger::builder().is_test(true).try_init();
+
     let mut options = Options::default();
     options.local_env = true;
     let initialized = true;
@@ -577,7 +606,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn test_request_already_inited_router_blackhole() {
+  async fn test_lambda_service_request_already_inited_router_blackhole() {
     // If you want to view logs during a test, uncomment this
     // let _ = env_logger::builder().is_test(true).try_init();
     let mut options = Options::default();
@@ -624,5 +653,219 @@ mod tests {
       duration <= std::time::Duration::from_secs(6),
       "Connection should take at most 6 seconds"
     );
+  }
+
+  #[tokio::test]
+  async fn test_lambda_request_router_connects_ping_panics() {
+    // If you want to view logs during a test, uncomment this
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Start router server
+    let (release_request_tx, release_request_rx) = tokio::sync::mpsc::channel::<()>(1);
+    let release_request_rx = Arc::new(tokio::sync::Mutex::new(release_request_rx));
+    // Use an arc int to count how many times the request endpoint was called
+    let request_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let request_count_clone = Arc::clone(&request_count);
+    let ping_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ping_count_clone = Arc::clone(&ping_count);
+    let close_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let close_count_clone = Arc::clone(&close_count);
+    let app = Router::new()
+      .route(
+        "/api/chunked/request/:lambda_id/:channel_id",
+        post(
+          move |Path((_lambda_id, _channel_id)): Path<(String, String)>,
+              request: axum::extract::Request| {
+          let request_count = Arc::clone(&request_count_clone);
+          let release_request_rx = Arc::clone(&release_request_rx);
+
+          async move {
+            // Spawn a task to write to the stream
+            tokio::spawn(async move {
+              let parts = request.into_parts();
+
+              parts
+                .1
+                .into_data_stream()
+                .for_each(|chunk| async {
+                  let chunk = chunk.unwrap();
+                  println!("Chunk: {:?}", chunk);
+                })
+                .await;
+
+              println!(
+                "Router Channel - Request body (for contained app response) finished writing"
+              );
+            });
+
+            // Increment the request count
+            request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            println!(
+              "Request count: {}",
+              request_count.load(std::sync::atomic::Ordering::SeqCst)
+            );
+
+            // Bail after 1st request
+            if request_count.load(std::sync::atomic::Ordering::SeqCst) > 1 {
+              let body = AsyncReadBody::new(tokio::io::empty());
+              let response = Response::builder()
+                .status(StatusCode::CONFLICT)
+                .body(body)
+                .unwrap();
+
+              return response;
+            }
+
+            // Create a channel for the stream
+            let (mut tx, rx) = tokio::io::duplex(65_536);
+
+            // Spawn a task to write to the stream
+            tokio::spawn(async move {
+              //
+              // Tell extension to GOAWAY
+              //
+              let data = b"GET /bananas HTTP/1.1\r\nHost: localhost\r\nTest-Header: foo\r\n";
+              tx.write_all(data).await.unwrap();
+
+              // Write the rest of the headers
+              let data = b"Test-Headers: bar\r\nTest-Headerss: baz\r\nAccept-Encoding: gzip\r\n\r\nHELLO WORLD";
+              tx.write_all(data).await.unwrap();
+
+              // Wait for the release
+              release_request_rx.lock().await.recv().await;
+
+              // Close the body stream
+              tx.shutdown().await.unwrap();
+
+              println!(
+                "Router Channel - Response body (for contained app request) finished reading"
+              );
+            });
+
+            let body = AsyncReadBody::new(rx);
+
+            let response = Response::builder()
+              .header("content-type", "application/octet-stream")
+              .body(body)
+              .unwrap();
+
+            response
+          }
+        },
+        ),
+      )
+      .route(
+        "/api/chunked/ping/:lambda_id",
+        get(|Path(lambda_id): Path<String>| async move {
+          let ping_count = Arc::clone(&ping_count_clone);
+          // Increment
+          ping_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+          // Panic so the stream closes
+          panic!("Ping! LambdaID: {}", lambda_id);
+        }),
+      )
+      .route(
+        "/api/chunked/close/:lambda_id",
+        get(|Path(lambda_id): Path<String>| async move {
+          let close_count = Arc::clone(&close_count_clone);
+          // Increment
+          close_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+          log::info!("Close! LambdaID: {}", lambda_id);
+          format!("Close! LambdaID: {}", lambda_id)
+        }),
+      );
+
+    let mock_router_server = run_http2_app(app);
+    let mock_router_endpoint = Endpoint::new(
+      crate::endpoint::Scheme::Http,
+      "127.0.0.1",
+      mock_router_server.addr.port(),
+    );
+
+    // Start app server
+    let mock_app_server = MockServer::start();
+    let mock_app_healthcheck = mock_app_server.mock(|when, then| {
+      when.method(GET).path("/health");
+      then.status(200).body("OK");
+    });
+    let mock_app_bananas = mock_app_server.mock(|when, then| {
+      when.method(GET).path("/bananas");
+      then
+        .status(200)
+        .header("Content-Type", "text/plain")
+        .header("Connection", "close")
+        .header("Keep-Alive", "timeout=5")
+        .body("Bananas");
+    });
+
+    // Blow up the mock router server
+    // Release the request after a few seconds
+    tokio::spawn(async move {
+      tokio::time::sleep(tokio::time::Duration::from_secs(6)).await;
+      release_request_tx.send(()).await.unwrap();
+    });
+
+    // If you want to view logs during a test, uncomment this
+    // let _ = env_logger::builder().is_test(true).try_init();
+    let mut options = Options::default();
+    // options.force_deadline_secs = Some(std::time::Duration::from_secs(15));
+    options.port = mock_app_server.address().port();
+    let initialized = true;
+
+    let service = LambdaService::new(
+      options,
+      Arc::new(AtomicBool::new(initialized)),
+      format!("{}/health", mock_app_server.base_url())
+        .parse()
+        .unwrap(),
+    );
+    let request = WaiterRequest {
+      pool_id: Some("test_pool".to_string()),
+      id: "test_id".to_string(),
+      router_url: format!("http://127.0.0.1:{}", mock_router_server.addr.port()),
+      number_of_channels: 1,
+      sent_time: "2022-01-01T00:00:00Z".to_string(),
+      init_only: false,
+    };
+    let mut context = lambda_runtime::Context::default();
+    // Test an overly large value to exercise trimming code
+    context.deadline = current_time_millis() + 60 * 1000;
+    let event = LambdaEvent {
+      payload: request,
+      context,
+    };
+
+    // Act
+    let start = std::time::Instant::now();
+    let response = service.fetch_response(event).await;
+    let duration = std::time::Instant::now().duration_since(start);
+
+    // Assert
+    assert!(response.is_ok(), "fetch_response should succeed");
+    match response {
+      Ok(waiter_response) => {
+        assert_eq!(
+          waiter_response.exit_reason,
+          messages::ExitReason::RouterConnectionError,
+        );
+      }
+      Err(err) => {
+        assert!(false, "Expected Ok with ExitReason, got Err: {:?}", err);
+      }
+    }
+    assert!(
+      duration > std::time::Duration::from_secs(6),
+      "Connection should take at least 6 seconds"
+    );
+    assert!(
+      duration <= std::time::Duration::from_secs(7),
+      "Connection should take at most 7 seconds"
+    );
+
+    // Healthcheck not called
+    mock_app_healthcheck.assert_hits(0);
+    // Bananas called once
+    mock_app_bananas.assert_hits(1);
   }
 }

--- a/extension/src/lambda_service.rs
+++ b/extension/src/lambda_service.rs
@@ -759,9 +759,7 @@ mod tests {
     mock_app_bananas.assert_hits(1);
   }
 
-  // This test is reporting that the app connection has errored
   #[tokio::test]
-  #[ignore = "Issue-178 - This test fails because we don't try to send a close to the router or configure a timeout if the ping loop exits"]
   async fn test_lambda_request_router_connects_ping_panics_channel_stays_open() {
     // Start router server
     let mock_router_server = test_mock_router::test_mock_router::setup_router(

--- a/extension/src/lambda_service.rs
+++ b/extension/src/lambda_service.rs
@@ -1053,11 +1053,6 @@ mod tests {
         assert!(false, "Expected Ok with ExitReason, got Err: {:?}", err);
       }
     }
-    assert!(
-      duration <= std::time::Duration::from_secs(3),
-      "Test should take at most 3 seconds, took: {:.1}",
-      duration.as_secs_f64()
-    );
 
     // Healthcheck not called
     mock_app_healthcheck.assert_hits(0);

--- a/extension/src/main.rs
+++ b/extension/src/main.rs
@@ -22,6 +22,7 @@ mod connect_to_router;
 mod counter_drop;
 mod endpoint;
 mod lambda_request;
+mod lambda_request_error;
 mod lambda_service;
 mod messages;
 mod options;

--- a/extension/src/main.rs
+++ b/extension/src/main.rs
@@ -29,9 +29,13 @@ mod options;
 mod ping;
 pub mod prelude;
 mod router_channel;
-mod test_http2_server;
 mod threads;
 mod time;
+
+#[cfg(test)]
+mod test_http2_server;
+#[cfg(test)]
+mod test_mock_router;
 
 fn main() -> Result<()> {
   env_logger::Builder::new()

--- a/extension/src/main.rs
+++ b/extension/src/main.rs
@@ -192,7 +192,26 @@ async fn async_main(options: Options) -> Result<()> {
           match lambda_result {
               Ok(_) => {}
               Err(e) => {
-                log::error!("Error: {}", e);
+                // Probably should change this to a panic
+                log::error!("Fatal Error in lambda_runtime::run: {}", e);
+
+                //
+                // To reproduce:
+                // - In deployed lambda
+                //   - Set LAMBDA_DISPATCH_PORT to an invalid port like 54321
+                //   - Set LAMBDA_DISPATCH_ASYNC_INIT to true
+                //   - Invoke the lambda
+                //   - The lambda will start, spillover the init to the handler,
+                //     then exit hard when it cannot connect to the app
+                // - Locally
+                //   - Use LambdaTestTool
+                //   - Make sure the demo-app is not running
+                //   - Set async init as above
+                //   - Invoke with the payload:
+                //     { "Id": "lambda_id", "DispatcherUrl": "http://127.0.0.1:3000", "NumberOfChannels": 1, "SentTime": "2025-01-01T00:00:00Z", "InitOnly": false }
+                //
+
+                //panic!("Fatal Error in lambda_runtime::run: {}", e);
               }
           }
       }

--- a/extension/src/messages.rs
+++ b/extension/src/messages.rs
@@ -41,6 +41,8 @@ pub enum ExitReason {
   SelfInitOnly,
   #[serde(rename = "SelfStaleRequest")]
   SelfStaleRequest,
+  #[serde(rename = "AppConnectionError")]
+  AppConnectionError,
   #[serde(rename = "AppConnectionClosed")]
   AppConnectionClosed,
   #[serde(rename = "RouterConnectionError")]
@@ -55,6 +57,8 @@ pub enum ExitReason {
   RouterStatus5xx,
   #[serde(rename = "RouterStatusOther")]
   RouterStatusOther,
+  #[serde(rename = "ChannelErrorOther")]
+  ChannelErrorOther,
 }
 
 impl ExitReason {
@@ -64,6 +68,8 @@ impl ExitReason {
     let ordered_reasons = [
       RouterUnreachable,
       RouterConnectionError,
+      ChannelErrorOther,
+      AppConnectionError,
       AppConnectionClosed,
       RouterStatus5xx,
       RouterStatus4xx,
@@ -75,13 +81,38 @@ impl ExitReason {
       SelfInitOnly,
     ];
 
-    for &reason in &ordered_reasons {
+    for reason in ordered_reasons {
       if self == reason || other == reason {
         return reason;
       }
     }
 
     self // If no match is found, return the current value
+  }
+
+  // This function will cause a compile-time error if a new variant is added to the enum
+  // but not added to the match expression.
+  #[allow(dead_code)]
+  fn ensure_all_variants_handled(variant: Self) {
+    use ExitReason::*;
+
+    match variant {
+      // HEY - If you add here you need to add to the `worse` function array above
+      RouterUnreachable => {}
+      RouterConnectionError => {}
+      ChannelErrorOther => {}
+      AppConnectionError => {}
+      AppConnectionClosed => {}
+      RouterStatus5xx => {}
+      RouterStatus4xx => {}
+      RouterStatusOther => {}
+      RouterGoaway => {}
+      SelfLastActive => {}
+      SelfDeadline => {}
+      SelfStaleRequest => {}
+      SelfInitOnly => {}
+    }
+    // HEY - If you add here you need to add to the `worse` function array above
   }
 }
 

--- a/extension/src/messages.rs
+++ b/extension/src/messages.rs
@@ -58,8 +58,8 @@ pub enum ExitReason {
   RouterConnectionError,
   #[serde(rename = "RouterUnreachable")]
   RouterUnreachable,
-  #[serde(rename = "RouterGoaway")]
-  RouterGoaway,
+  #[serde(rename = "RouterGoAway")]
+  RouterGoAway,
   #[serde(rename = "RouterStatus4xx")]
   RouterStatus4xx,
   #[serde(rename = "RouterStatus5xx")]
@@ -84,7 +84,7 @@ impl ExitReason {
       RouterStatus5xx,
       RouterStatus4xx,
       RouterStatusOther,
-      RouterGoaway,
+      RouterGoAway,
       SelfLastActive,
       SelfDeadline,
       SelfStaleRequest,
@@ -117,7 +117,7 @@ impl ExitReason {
       RouterStatus5xx => {}
       RouterStatus4xx => {}
       RouterStatusOther => {}
-      RouterGoaway => {}
+      RouterGoAway => {}
       SelfLastActive => {}
       SelfDeadline => {}
       SelfStaleRequest => {}
@@ -134,7 +134,7 @@ impl WaiterResponse {
       id,
       request_count: 0,
       invoke_duration: 0,
-      exit_reason: ExitReason::RouterGoaway,
+      exit_reason: ExitReason::RouterGoAway,
     }
   }
 }

--- a/extension/src/messages.rs
+++ b/extension/src/messages.rs
@@ -45,6 +45,8 @@ pub enum ExitReason {
   AppConnectionError,
   #[serde(rename = "AppConnectionClosed")]
   AppConnectionClosed,
+  #[serde(rename = "RouterLambdaInvokeInvalid")]
+  RouterLambdaInvokeInvalid,
   #[serde(rename = "RouterConnectionError")]
   RouterConnectionError,
   #[serde(rename = "RouterUnreachable")]
@@ -66,6 +68,7 @@ impl ExitReason {
     use ExitReason::*;
 
     let ordered_reasons = [
+      RouterLambdaInvokeInvalid,
       RouterUnreachable,
       RouterConnectionError,
       ChannelErrorOther,
@@ -98,6 +101,7 @@ impl ExitReason {
 
     match variant {
       // HEY - If you add here you need to add to the `worse` function array above
+      RouterLambdaInvokeInvalid => {}
       RouterUnreachable => {}
       RouterConnectionError => {}
       ChannelErrorOther => {}

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -16,9 +16,9 @@ use hyper::{
   Request, StatusCode,
 };
 
-use crate::endpoint::Endpoint;
 use crate::prelude::*;
 use crate::time;
+use crate::{endpoint::Endpoint, messages};
 
 #[derive(PartialEq, Debug)]
 pub enum PingResult {
@@ -32,6 +32,21 @@ pub enum PingResult {
   StatusCodeOther,
 }
 
+impl From<PingResult> for Option<messages::ExitReason> {
+  fn from(ping_result: PingResult) -> Self {
+    match ping_result {
+      PingResult::GoAway => Some(messages::ExitReason::RouterGoaway),
+      PingResult::Deadline => Some(messages::ExitReason::SelfDeadline),
+      PingResult::LastActive => Some(messages::ExitReason::SelfLastActive),
+      PingResult::CancelToken => None,
+      PingResult::ConnectionError => Some(messages::ExitReason::RouterConnectionError),
+      PingResult::StatusCode5xx => Some(messages::ExitReason::RouterStatus5xx),
+      PingResult::StatusCode4xx => Some(messages::ExitReason::RouterStatus4xx),
+      PingResult::StatusCodeOther => Some(messages::ExitReason::RouterStatus4xx),
+    }
+  }
+}
+
 pub async fn send_ping_requests(
   last_active: Arc<AtomicU64>,
   goaway_received: Arc<AtomicBool>,
@@ -43,8 +58,8 @@ pub async fn send_ping_requests(
   deadline_ms: u64,
   cancel_token: tokio_util::sync::CancellationToken,
   requests_in_flight: Arc<AtomicUsize>,
-) -> PingResult {
-  let mut result = PingResult::GoAway;
+) -> Option<PingResult> {
+  let mut result = None;
   let start_time = time::current_time_millis();
   let mut last_ping_time = start_time;
 
@@ -106,7 +121,7 @@ pub async fn send_ping_requests(
           elapsed,
           rps
         );
-        result = PingResult::LastActive;
+        result = Some(PingResult::LastActive);
       } else if time::current_time_millis() + close_before_deadline_ms > deadline_ms {
         log::info!(
           "PoolId: {}, LambdaId: {}, Deadline: {} ms Away, Reqs in Flight: {}, Elapsed: {} ms, RPS: {} - Requesting close: Deadline",
@@ -117,7 +132,7 @@ pub async fn send_ping_requests(
           elapsed,
           rps
         );
-        result = PingResult::Deadline;
+        result = Some(PingResult::Deadline);
       }
 
       // Send Close request to router
@@ -138,7 +153,7 @@ pub async fn send_ping_requests(
       if sender.ready().await.is_err() {
         // This gets hit when the connection for HTTP/1.1 faults
         goaway_received.store(true, Ordering::Release);
-        result = PingResult::ConnectionError;
+        result = Some(PingResult::ConnectionError);
         log::error!(
           "Ping Loop - Router connection ready check threw error - connection has disconnected, exiting"
         );
@@ -187,7 +202,7 @@ pub async fn send_ping_requests(
 
       if sender.ready().await.is_err() {
         // This gets hit when the connection faults
-        result = PingResult::ConnectionError;
+        result = Some(PingResult::ConnectionError);
         goaway_received.store(true, Ordering::Release);
         log::error!("PoolId: {}, LambdaId: {} - Ping Loop - Connection ready check threw error - connection has disconnected, exiting", pool_id, lambda_id);
         break;
@@ -208,17 +223,18 @@ pub async fn send_ping_requests(
               pool_id,
               lambda_id
             );
+            result = Some(PingResult::GoAway);
             goaway_received.store(true, Ordering::Release);
             break;
           }
 
           if parts.status != StatusCode::OK {
             if parts.status.is_server_error() {
-              result = PingResult::StatusCode5xx;
+              result = Some(PingResult::StatusCode5xx);
             } else if parts.status.is_client_error() {
-              result = PingResult::StatusCode4xx;
+              result = Some(PingResult::StatusCode4xx);
             } else {
-              result = PingResult::StatusCodeOther;
+              result = Some(PingResult::StatusCodeOther);
             }
             log::info!(
               "PoolId: {}, LambdaId: {} - Ping Loop - non-200 received on ping, exiting: {:?}",
@@ -231,7 +247,7 @@ pub async fn send_ping_requests(
           }
         }
         Err(err) => {
-          result = PingResult::ConnectionError;
+          result = Some(PingResult::ConnectionError);
           log::error!(
             "PoolId: {}, LambdaId: {} - Ping Loop - Ping request failed: {:?}",
             pool_id,
@@ -239,6 +255,7 @@ pub async fn send_ping_requests(
             err
           );
           goaway_received.store(true, Ordering::Release);
+          break;
         }
       }
 
@@ -267,7 +284,7 @@ pub async fn send_ping_requests(
             rps
           );
 
-          result = PingResult::CancelToken;
+          result = Some(PingResult::CancelToken);
         }
         _ = tokio::time::sleep(Duration::from_millis(100)) => {
         }
@@ -373,7 +390,11 @@ mod tests {
     .await;
 
     // Assert
-    assert_eq!(result, PingResult::Deadline, "result should be Deadline");
+    assert_eq!(
+      result,
+      Some(PingResult::Deadline),
+      "result should be Deadline"
+    );
     assert_eq!(
       ping_count.load(std::sync::atomic::Ordering::SeqCst),
       0,
@@ -479,7 +500,7 @@ mod tests {
     // Assert
     assert_eq!(
       result,
-      PingResult::LastActive,
+      Some(PingResult::LastActive),
       "result should be LastActive"
     );
     assert_eq!(
@@ -593,7 +614,7 @@ mod tests {
     // Assert
     assert_eq!(
       result,
-      PingResult::CancelToken,
+      Some(PingResult::CancelToken),
       "result should be CancelToken"
     );
     assert_eq!(
@@ -625,25 +646,29 @@ mod tests {
 
   #[tokio::test]
   async fn test_ping_channel_status_305() {
-    test_ping_status_code(StatusCode::USE_PROXY, PingResult::StatusCodeOther).await;
+    test_ping_status_code(StatusCode::USE_PROXY, Some(PingResult::StatusCodeOther)).await;
   }
 
   #[tokio::test]
   async fn test_ping_channel_status_400() {
-    test_ping_status_code(StatusCode::BAD_REQUEST, PingResult::StatusCode4xx).await;
+    test_ping_status_code(StatusCode::BAD_REQUEST, Some(PingResult::StatusCode4xx)).await;
   }
 
   #[tokio::test]
   async fn test_ping_channel_status_409() {
-    test_ping_status_code(StatusCode::CONFLICT, PingResult::GoAway).await;
+    test_ping_status_code(StatusCode::CONFLICT, Some(PingResult::GoAway)).await;
   }
 
   #[tokio::test]
   async fn test_ping_channel_status_500() {
-    test_ping_status_code(StatusCode::INTERNAL_SERVER_ERROR, PingResult::StatusCode5xx).await;
+    test_ping_status_code(
+      StatusCode::INTERNAL_SERVER_ERROR,
+      Some(PingResult::StatusCode5xx),
+    )
+    .await;
   }
 
-  async fn test_ping_status_code(status_code: StatusCode, expected_result: PingResult) {
+  async fn test_ping_status_code(status_code: StatusCode, expected_result: Option<PingResult>) {
     let lambda_id = "lambda_id".to_string();
     let pool_id = "pool_id".to_string();
 
@@ -838,7 +863,7 @@ mod tests {
     // Assert
     assert_eq!(
       result,
-      PingResult::ConnectionError,
+      Some(PingResult::ConnectionError),
       "result should be ConnectionError"
     );
     assert_eq!(

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -440,10 +440,6 @@ mod tests {
           let ping_count = Arc::clone(&ping_count_clone);
           // Increment
           ping_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-          println!(
-            "Ping count: {}",
-            ping_count.load(std::sync::atomic::Ordering::SeqCst)
-          );
           format!("Ping! LambdaID: {}", lambda_id)
         }),
       )
@@ -685,10 +681,6 @@ mod tests {
           let ping_count = Arc::clone(&ping_count_clone);
           // Increment
           ping_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-          println!(
-            "Ping count: {}",
-            ping_count.load(std::sync::atomic::Ordering::SeqCst)
-          );
           (status_code, format!("Ping! LambdaID: {}", lambda_id))
         }),
       )
@@ -799,11 +791,6 @@ mod tests {
           let ping_count = Arc::clone(&ping_count_clone);
           // Increment
           ping_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-          println!(
-            "Ping count: {}",
-            ping_count.load(std::sync::atomic::Ordering::SeqCst)
-          );
-
           panic!("Connection closed")
         }),
       )

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -35,7 +35,7 @@ pub enum PingResult {
 impl From<PingResult> for Option<messages::ExitReason> {
   fn from(result: PingResult) -> Self {
     match result {
-      PingResult::GoAway => Some(messages::ExitReason::RouterGoaway),
+      PingResult::GoAway => Some(messages::ExitReason::RouterGoAway),
       PingResult::Deadline => Some(messages::ExitReason::SelfDeadline),
       PingResult::LastActive => Some(messages::ExitReason::SelfLastActive),
       PingResult::CancelToken => None,

--- a/extension/src/ping.rs
+++ b/extension/src/ping.rs
@@ -294,14 +294,14 @@ pub async fn send_ping_requests(
   let count = count.load(Ordering::Acquire);
   let elapsed = time::current_time_millis() - start_time;
   log::info!(
-    "PoolId: {}, LambdaId: {}, Requests: {}, GoAway: {}, Reqs in Flight: {}, Elapsed: {} ms, RPS: {} - Ping Loop - Exiting",
+    "PoolId: {}, LambdaId: {}, Requests: {}, GoAway: {}, Reqs in Flight: {}, Elapsed: {} ms, RPS: {:.1} - Ping Loop - Exiting",
     pool_id,
     lambda_id,
     count,
     goaway_received.load(Ordering::Acquire),
     requests_in_flight.load(Ordering::Acquire),
     elapsed,
-    format!("{:.1}", count as f64 / (elapsed as f64 / 1000.0))
+    count as f64 / (elapsed as f64 / 1000.0)
   );
 
   result

--- a/extension/src/router_channel.rs
+++ b/extension/src/router_channel.rs
@@ -91,7 +91,7 @@ impl RouterChannel {
       Arc::clone(&self.channel_id),
     )
     .await
-    .map_err(|_| LambdaRequestError::AppConnectionError)?;
+    .map_err(|_| LambdaRequestError::AppConnectionUnreachable)?;
 
     // This is where HTTP2 loops to make all the requests for a given client and worker
     // If the pinger or another channel sets the goaway we will stop looping

--- a/extension/src/router_channel.rs
+++ b/extension/src/router_channel.rs
@@ -37,7 +37,7 @@ pub enum ChannelResult {
 impl From<ChannelResult> for messages::ExitReason {
   fn from(result: ChannelResult) -> Self {
     match result {
-      ChannelResult::GoAwayReceived => messages::ExitReason::RouterGoaway,
+      ChannelResult::GoAwayReceived => messages::ExitReason::RouterGoAway,
       ChannelResult::RouterStatus5xx => messages::ExitReason::RouterStatus5xx,
       ChannelResult::RouterStatus4xx => messages::ExitReason::RouterStatus4xx,
       ChannelResult::RouterStatusOther => messages::ExitReason::RouterStatusOther,

--- a/extension/src/router_channel.rs
+++ b/extension/src/router_channel.rs
@@ -93,7 +93,6 @@ impl RouterChannel {
 
     // This is where HTTP2 loops to make all the requests for a given client and worker
     loop {
-      // let requests_in_flight = Arc::clone(&requests_in_flight);
       let mut _decrement_on_drop = None;
 
       // Create the router request
@@ -237,7 +236,6 @@ impl RouterChannel {
       let pool_id_clone = self.pool_id.clone();
       let lambda_id_clone = self.lambda_id.clone();
       let requests_in_flight_clone = Arc::clone(&self.requests_in_flight);
-      // let requests_in_flight_clone = Arc::clone(&self.requests_in_flight);
       let relay_task = tokio::task::spawn(async move {
         let mut bytes_sent = 0;
 

--- a/extension/src/router_channel.rs
+++ b/extension/src/router_channel.rs
@@ -636,12 +636,6 @@ mod tests {
           async move {
             // Increment the request count
             request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            println!(
-              "LambdaID: {}, ChannelID: {}, Request count: {}",
-              lambda_id,
-              channel_id,
-              request_count.load(std::sync::atomic::Ordering::SeqCst)
-            );
 
             // Return a 409
             (StatusCode::CONFLICT, b"Request already made")
@@ -752,22 +746,14 @@ mod tests {
                 .1
                 .into_data_stream()
                 .for_each(|chunk| async {
-                  let chunk = chunk.unwrap();
-                  println!("Chunk: {:?}", chunk);
+                  let _chunk = chunk.unwrap();
+                  // println!("Chunk: {:?}", chunk);
                 })
                 .await;
-
-              println!(
-                "Router Channel - Request body (for contained app response) finished writing"
-              );
             });
 
             // Increment the request count
             request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            println!(
-              "Request count: {}",
-              request_count.load(std::sync::atomic::Ordering::SeqCst)
-            );
 
             // Bail after 1st request
             if request_count.load(std::sync::atomic::Ordering::SeqCst) > 1 {
@@ -798,10 +784,6 @@ mod tests {
 
               // Close the stream
               tx.shutdown().await.unwrap();
-
-              println!(
-                "Router Channel - Response body (for contained app request) finished reading"
-              );
             });
 
             let body = AsyncReadBody::new(rx);
@@ -948,10 +930,6 @@ mod tests {
           async move {
             // Increment the request count
             request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            println!(
-              "Request count: {}",
-              request_count.load(std::sync::atomic::Ordering::SeqCst)
-            );
 
             // Create a channel for the stream
             let (mut tx, rx) = tokio::io::duplex(65_536);
@@ -974,10 +952,6 @@ mod tests {
 
               // Close the stream
               tx.shutdown().await.unwrap();
-
-              println!(
-                "Router Channel - Response body (for contained app request) finished reading"
-              );
             });
 
             let body = AsyncReadBody::new(rx);

--- a/extension/src/router_channel.rs
+++ b/extension/src/router_channel.rs
@@ -547,7 +547,6 @@ impl RouterChannel {
           }
         }
 
-        // Errors here are ignored because the channel is closing
         if let Some(encoder) = encoder.take() {
           let writer = encoder.finish().unwrap();
           let bytes = writer.into_inner().into();

--- a/extension/src/router_channel.rs
+++ b/extension/src/router_channel.rs
@@ -92,7 +92,11 @@ impl RouterChannel {
     .await?;
 
     // This is where HTTP2 loops to make all the requests for a given client and worker
-    loop {
+    // If the pinger or another channel sets the goaway we will stop looping
+    while !self
+      .goaway_received
+      .load(std::sync::atomic::Ordering::Acquire)
+    {
       let mut _decrement_on_drop = None;
 
       // Create the router request

--- a/extension/src/test_mock_router.rs
+++ b/extension/src/test_mock_router.rs
@@ -18,7 +18,7 @@ pub mod test_mock_router {
   pub struct RouterParams {
     pub channel_conflict_after_count: isize,
     pub channel_panic_response_from_extension_on_count: isize,
-    pub channel_panic_request_to_extension_before_start: bool,
+    pub channel_panic_request_to_extension_before_start_on_count: isize,
     pub channel_panic_request_to_extension_after_start: bool,
     pub channel_panic_request_to_extension_before_close: bool,
     pub ping_panic_after_count: isize,
@@ -44,137 +44,137 @@ pub mod test_mock_router {
     let close_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let close_count_clone = Arc::clone(&close_count);
     let app = Router::new()
-     .route(
+      .route(
        "/api/chunked/request/:lambda_id/:channel_id",
        post(
          move |Path((_lambda_id, _channel_id)): Path<(String, String)>,
              request: axum::extract::Request| {
-         let request_count = Arc::clone(&request_count_clone);
-         let request_count_response = Arc::clone(&request_count_clone);
-         let release_request_rx = Arc::clone(&release_request_rx);
+        let request_count = Arc::clone(&request_count_clone);
+        let release_request_rx = Arc::clone(&release_request_rx);
 
-         async move {
-           // Spawn a task to read from the request (receiving response from extension)
-           // We do not do anything with the response other than log it
-           // This would normally go back to the client of the router
-           tokio::spawn(async move {
-             let parts = request.into_parts();
-
-             if params.channel_panic_response_from_extension_on_count == 0
-                || request_count_response.load(std::sync::atomic::Ordering::SeqCst) == params.channel_panic_response_from_extension_on_count as usize {
-               panic!("Panic! Response from extension");
-             }
-
-             parts
-               .1
-               .into_data_stream()
-               .for_each(|chunk| async {
-                 let chunk = chunk.unwrap();
-                 println!("Chunk: {:?}", chunk);
-               })
-               .await;
-
-             println!(
-               "Router Channel - Request body (for contained app response) finished reading"
-             );
-           });
-
-           // Increment the request count
-           request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-           println!(
-             "Request count: {}",
-             request_count.load(std::sync::atomic::Ordering::SeqCst)
-           );
-
-           // Bail after request count if desired
-           if params.channel_conflict_after_count >= 0 && request_count.load(std::sync::atomic::Ordering::SeqCst) > params.channel_conflict_after_count as usize {
-             let body = AsyncReadBody::new(tokio::io::empty());
-             let response = Response::builder()
-               .status(StatusCode::CONFLICT)
-               .body(body)
-               .unwrap();
-
-             return response;
-           }
-
-           // Create a channel for the stream
-           let (mut tx, rx) = tokio::io::duplex(65_536);
-
-           // Spawn a task to write to the response (sending request to extension)
-           tokio::spawn(async move {
-              if params.channel_panic_request_to_extension_before_start {
-                panic!("Panic! Request to extension, before sending VERB line");
-              }
-
-              // Send static request to extension
-              let data = b"GET /bananas HTTP/1.1\r\nHost: localhost\r\nTest-Header: foo\r\n";
-              tx.write_all(data).await.unwrap();
-
-              if params.channel_panic_request_to_extension_after_start {
-                panic!("Panic! Request to extension, after sending VERB line and some headers");
-              }
-
-              // Write the rest of the headers
-              let data = b"Test-Headers: bar\r\nTest-Headerss: baz\r\nAccept-Encoding: gzip\r\n\r\nHELLO WORLD";
-              tx.write_all(data).await.unwrap();
-
-              // Wait for the release before indicating that the body is finished
-              // Keep in mind that this is HTTP/1.1 WITHOUT CHUNKING and WITHOUT CONTENT-LENGTH header
-              // We are sending this over HTTP2 so closing the stream is the only way to indicate the end of the body,
-              // similar to Transfer-Encoding: chunked
-              release_request_rx.lock().await.recv().await;
-
-              if params.channel_panic_request_to_extension_before_close {
-                panic!("Panic! Request to extension, before close");
-              }
-
-              // Close the body stream
-              tx.shutdown().await.unwrap();
-
-              println!(
-                "Router Channel - Response body (for contained app request) finished reading"
-              );
-           });
-
-           let body = AsyncReadBody::new(rx);
-
-           let response = Response::builder()
-             .header("content-type", "application/octet-stream")
-             .body(body)
-             .unwrap();
-
-           response
-         }
-       },
-       ),
-     )
-     .route(
-        "/api/chunked/ping/:lambda_id",
-       get(move |Path(lambda_id): Path<String>|
         async move {
-          let ping_count = Arc::clone(&ping_count_clone);
-          // Increment
-          ping_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+          // Increment the request count
+          request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+          let request_count = request_count.load(std::sync::atomic::Ordering::SeqCst);
+          println!(
+            "Request count: {}",
+            request_count
+          );
 
-          // Panic so the stream closes
-          if params.ping_panic_after_count >= 0 && ping_count.load(std::sync::atomic::Ordering::SeqCst) > params.ping_panic_after_count as usize {
-            panic!("Ping! LambdaID: {}", lambda_id);
+          // Spawn a task to read from the request (receiving response from extension)
+          // We do not do anything with the response other than log it
+          // This would normally go back to the client of the router
+          tokio::spawn(async move {
+            let parts = request.into_parts();
+
+            if params.channel_panic_response_from_extension_on_count == 0
+              || request_count == params.channel_panic_response_from_extension_on_count as usize {
+              panic!("Panic! Response from extension");
+            }
+
+            parts
+              .1
+              .into_data_stream()
+              .for_each(|chunk| async {
+                let chunk = chunk.unwrap();
+                println!("Chunk: {:?}", chunk);
+              })
+              .await;
+
+            println!(
+              "Router Channel - Request body (for contained app response) finished reading"
+            );
+          });
+
+          // Bail after request count if desired
+          if params.channel_conflict_after_count >= 0 && request_count > params.channel_conflict_after_count as usize {
+            let body = AsyncReadBody::new(tokio::io::empty());
+            let response = Response::builder()
+              .status(StatusCode::CONFLICT)
+              .body(body)
+              .unwrap();
+
+            return response;
           }
 
-          log::info!("Ping! LambdaID: {}", lambda_id);
-          format!("Ping! LambdaID: {}", lambda_id)
-       }),
-     )
-     .route(
-       "/api/chunked/close/:lambda_id",
-       get(move |Path(lambda_id): Path<String>| async move {
-         let close_count = Arc::clone(&close_count_clone);
-         // Increment
-         close_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-         log::info!("Close! LambdaID: {}", lambda_id);
-         format!("Close! LambdaID: {}", lambda_id)
-       }),
-     );
+          // Create a channel for the stream
+          let (mut tx, rx) = tokio::io::duplex(65_536);
+
+          // Spawn a task to write to the response (sending request to extension)
+          tokio::spawn(async move {
+            if params.channel_panic_response_from_extension_on_count == 0
+              || request_count == params.channel_panic_response_from_extension_on_count as usize {
+              panic!("Panic! Response from extension");
+            }
+
+            // Send static request to extension
+            let data = b"GET /bananas HTTP/1.1\r\nHost: localhost\r\nTest-Header: foo\r\n";
+            tx.write_all(data).await.unwrap();
+
+            if params.channel_panic_request_to_extension_after_start {
+              panic!("Panic! Request to extension, after sending VERB line and some headers");
+            }
+
+            // Write the rest of the headers
+            let data = b"Test-Headers: bar\r\nTest-Headerss: baz\r\nAccept-Encoding: gzip\r\n\r\nHELLO WORLD";
+            tx.write_all(data).await.unwrap();
+
+            // Wait for the release before indicating that the body is finished
+            // Keep in mind that this is HTTP/1.1 WITHOUT CHUNKING and WITHOUT CONTENT-LENGTH header
+            // We are sending this over HTTP2 so closing the stream is the only way to indicate the end of the body,
+            // similar to Transfer-Encoding: chunked
+            release_request_rx.lock().await.recv().await;
+
+            if params.channel_panic_request_to_extension_before_close {
+              panic!("Panic! Request to extension, before close");
+            }
+
+            // Close the body stream
+            tx.shutdown().await.unwrap();
+
+            println!(
+              "Router Channel - Response body (for contained app request) finished reading"
+            );
+          });
+
+          let body = AsyncReadBody::new(rx);
+
+          let response = Response::builder()
+            .header("content-type", "application/octet-stream")
+            .body(body)
+            .unwrap();
+
+          response
+        }
+      }),
+    )
+    .route(
+        "/api/chunked/ping/:lambda_id",
+      get(move |Path(lambda_id): Path<String>|
+      async move {
+        let ping_count = Arc::clone(&ping_count_clone);
+        // Increment
+        ping_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        // Panic so the stream closes
+        if params.ping_panic_after_count >= 0 && ping_count.load(std::sync::atomic::Ordering::SeqCst) > params.ping_panic_after_count as usize {
+          panic!("Ping! LambdaID: {}", lambda_id);
+        }
+
+        log::info!("Ping! LambdaID: {}", lambda_id);
+        format!("Ping! LambdaID: {}", lambda_id)
+      }),
+    )
+    .route(
+      "/api/chunked/close/:lambda_id",
+      get(move |Path(lambda_id): Path<String>| async move {
+        let close_count = Arc::clone(&close_count_clone);
+        // Increment
+        close_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        log::info!("Close! LambdaID: {}", lambda_id);
+        format!("Close! LambdaID: {}", lambda_id)
+      }),
+    );
 
     let mock_router_server = run_http2_app(app);
 

--- a/extension/src/test_mock_router.rs
+++ b/extension/src/test_mock_router.rs
@@ -16,7 +16,8 @@ pub mod test_mock_router {
 
   #[derive(Clone, Copy)]
   pub struct RouterParams {
-    pub channel_conflict_after_count: isize,
+    pub channel_non_200_status_after_count: isize,
+    pub channel_non_200_status_code: StatusCode,
     pub channel_panic_response_from_extension_on_count: isize,
     pub channel_panic_request_to_extension_before_start_on_count: isize,
     pub channel_panic_request_to_extension_after_start: bool,
@@ -79,10 +80,10 @@ pub mod test_mock_router {
           });
 
           // Bail after request count if desired
-          if params.channel_conflict_after_count >= 0 && request_count > params.channel_conflict_after_count as usize {
+          if params.channel_non_200_status_after_count >= 0 && request_count > params.channel_non_200_status_after_count as usize {
             let body = AsyncReadBody::new(tokio::io::empty());
             let response = Response::builder()
-              .status(StatusCode::CONFLICT)
+              .status(params.channel_non_200_status_code)
               .body(body)
               .unwrap();
 

--- a/extension/src/test_mock_router.rs
+++ b/extension/src/test_mock_router.rs
@@ -56,10 +56,6 @@ pub mod test_mock_router {
           // Increment the request count
           request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
           let request_count = request_count.load(std::sync::atomic::Ordering::SeqCst);
-          println!(
-            "Request count: {}",
-            request_count
-          );
 
           // Spawn a task to read from the request (receiving response from extension)
           // We do not do anything with the response other than log it
@@ -76,14 +72,10 @@ pub mod test_mock_router {
               .1
               .into_data_stream()
               .for_each(|chunk| async {
-                let chunk = chunk.unwrap();
-                println!("Chunk: {:?}", chunk);
+                let _chunk = chunk.unwrap();
+                // println!("Chunk: {:?}", chunk);
               })
               .await;
-
-            println!(
-              "Router Channel - Request body (for contained app response) finished reading"
-            );
           });
 
           // Bail after request count if desired
@@ -131,10 +123,6 @@ pub mod test_mock_router {
 
             // Close the body stream
             tx.shutdown().await.unwrap();
-
-            println!(
-              "Router Channel - Response body (for contained app request) finished reading"
-            );
           });
 
           let body = AsyncReadBody::new(rx);

--- a/extension/src/test_mock_router.rs
+++ b/extension/src/test_mock_router.rs
@@ -1,0 +1,187 @@
+#[cfg(test)]
+pub mod test_mock_router {
+  use std::sync::{atomic::AtomicUsize, Arc};
+
+  use crate::test_http2_server::test_http2_server::{run_http2_app, Serve};
+  use axum::{
+    extract::Path,
+    response::Response,
+    routing::{get, post},
+    Router,
+  };
+  use axum_extra::body::AsyncReadBody;
+  use futures::stream::StreamExt;
+  use hyper::StatusCode;
+  use tokio::{io::AsyncWriteExt, sync::mpsc::Sender};
+
+  #[derive(Clone, Copy)]
+  pub struct RouterParams {
+    pub channel_conflict_after_count: isize,
+    pub channel_panic_response_from_extension: bool,
+    pub channel_panic_request_to_extension_before_start: bool,
+    pub channel_panic_request_to_extension_after_start: bool,
+    pub channel_panic_request_to_extension_before_close: bool,
+    pub ping_panic_after_count: isize,
+  }
+
+  pub struct RouterResult {
+    pub release_request_tx: Sender<()>,
+    pub request_count: Arc<AtomicUsize>,
+    pub ping_count: Arc<AtomicUsize>,
+    pub close_count: Arc<AtomicUsize>,
+    pub mock_router_server: Serve,
+  }
+
+  pub fn setup_router(params: RouterParams) -> RouterResult {
+    // Start router server
+    let (release_request_tx, release_request_rx) = tokio::sync::mpsc::channel::<()>(1);
+    let release_request_rx = Arc::new(tokio::sync::Mutex::new(release_request_rx));
+    // Use an arc int to count how many times the request endpoint was called
+    let request_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let request_count_clone = Arc::clone(&request_count);
+    let ping_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ping_count_clone = Arc::clone(&ping_count);
+    let close_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let close_count_clone = Arc::clone(&close_count);
+    let app = Router::new()
+     .route(
+       "/api/chunked/request/:lambda_id/:channel_id",
+       post(
+         move |Path((_lambda_id, _channel_id)): Path<(String, String)>,
+             request: axum::extract::Request| {
+         let request_count = Arc::clone(&request_count_clone);
+         let release_request_rx = Arc::clone(&release_request_rx);
+
+         async move {
+           // Spawn a task to read from the request (receiving response from extension)
+           // We do not do anything with the response other than log it
+           // This would normally go back to the client of the router
+           tokio::spawn(async move {
+             let parts = request.into_parts();
+
+             if params.channel_panic_response_from_extension {
+               panic!("Panic! Response from extension");
+             }
+
+             parts
+               .1
+               .into_data_stream()
+               .for_each(|chunk| async {
+                 let chunk = chunk.unwrap();
+                 println!("Chunk: {:?}", chunk);
+               })
+               .await;
+
+             println!(
+               "Router Channel - Request body (for contained app response) finished reading"
+             );
+           });
+
+           // Increment the request count
+           request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+           println!(
+             "Request count: {}",
+             request_count.load(std::sync::atomic::Ordering::SeqCst)
+           );
+
+           // Bail after request count if desired
+           if params.channel_conflict_after_count >= 0 && request_count.load(std::sync::atomic::Ordering::SeqCst) > params.channel_conflict_after_count as usize {
+             let body = AsyncReadBody::new(tokio::io::empty());
+             let response = Response::builder()
+               .status(StatusCode::CONFLICT)
+               .body(body)
+               .unwrap();
+
+             return response;
+           }
+
+           // Create a channel for the stream
+           let (mut tx, rx) = tokio::io::duplex(65_536);
+
+           // Spawn a task to write to the response (sending request to extension)
+           tokio::spawn(async move {
+              if params.channel_panic_request_to_extension_before_start {
+                panic!("Panic! Request to extension, before sending VERB line");
+              }
+
+              // Send static request to extension
+              let data = b"GET /bananas HTTP/1.1\r\nHost: localhost\r\nTest-Header: foo\r\n";
+              tx.write_all(data).await.unwrap();
+
+              if params.channel_panic_request_to_extension_after_start {
+                panic!("Panic! Request to extension, after sending VERB line and some headers");
+              }
+
+              // Write the rest of the headers
+              let data = b"Test-Headers: bar\r\nTest-Headerss: baz\r\nAccept-Encoding: gzip\r\n\r\nHELLO WORLD";
+              tx.write_all(data).await.unwrap();
+
+              // Wait for the release before indicating that the body is finished
+              // Keep in mind that this is HTTP/1.1 WITHOUT CHUNKING and WITHOUT CONTENT-LENGTH header
+              // We are sending this over HTTP2 so closing the stream is the only way to indicate the end of the body,
+              // similar to Transfer-Encoding: chunked
+              release_request_rx.lock().await.recv().await;
+
+              if params.channel_panic_request_to_extension_before_close {
+                panic!("Panic! Request to extension, before close");
+              }
+
+              // Close the body stream
+              tx.shutdown().await.unwrap();
+
+              println!(
+                "Router Channel - Response body (for contained app request) finished reading"
+              );
+           });
+
+           let body = AsyncReadBody::new(rx);
+
+           let response = Response::builder()
+             .header("content-type", "application/octet-stream")
+             .body(body)
+             .unwrap();
+
+           response
+         }
+       },
+       ),
+     )
+     .route(
+        "/api/chunked/ping/:lambda_id",
+       get(move |Path(lambda_id): Path<String>|
+        async move {
+          let ping_count = Arc::clone(&ping_count_clone);
+          // Increment
+          ping_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+          // Panic so the stream closes
+          if params.ping_panic_after_count >= 0 && ping_count.load(std::sync::atomic::Ordering::SeqCst) > params.ping_panic_after_count as usize {
+            panic!("Ping! LambdaID: {}", lambda_id);
+          }
+
+          log::info!("Ping! LambdaID: {}", lambda_id);
+          format!("Ping! LambdaID: {}", lambda_id)
+       }),
+     )
+     .route(
+       "/api/chunked/close/:lambda_id",
+       get(move |Path(lambda_id): Path<String>| async move {
+         let close_count = Arc::clone(&close_count_clone);
+         // Increment
+         close_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+         log::info!("Close! LambdaID: {}", lambda_id);
+         format!("Close! LambdaID: {}", lambda_id)
+       }),
+     );
+
+    let mock_router_server = run_http2_app(app);
+
+    RouterResult {
+      release_request_tx,
+      request_count,
+      ping_count,
+      close_count,
+      mock_router_server,
+    }
+  }
+}

--- a/extension/src/test_mock_router.rs
+++ b/extension/src/test_mock_router.rs
@@ -17,7 +17,7 @@ pub mod test_mock_router {
   #[derive(Clone, Copy)]
   pub struct RouterParams {
     pub channel_conflict_after_count: isize,
-    pub channel_panic_response_from_extension: bool,
+    pub channel_panic_response_from_extension_on_count: isize,
     pub channel_panic_request_to_extension_before_start: bool,
     pub channel_panic_request_to_extension_after_start: bool,
     pub channel_panic_request_to_extension_before_close: bool,
@@ -50,6 +50,7 @@ pub mod test_mock_router {
          move |Path((_lambda_id, _channel_id)): Path<(String, String)>,
              request: axum::extract::Request| {
          let request_count = Arc::clone(&request_count_clone);
+         let request_count_response = Arc::clone(&request_count_clone);
          let release_request_rx = Arc::clone(&release_request_rx);
 
          async move {
@@ -59,7 +60,8 @@ pub mod test_mock_router {
            tokio::spawn(async move {
              let parts = request.into_parts();
 
-             if params.channel_panic_response_from_extension {
+             if params.channel_panic_response_from_extension_on_count == 0
+                || request_count_response.load(std::sync::atomic::Ordering::SeqCst) == params.channel_panic_response_from_extension_on_count as usize {
                panic!("Panic! Response from extension");
              }
 


### PR DESCRIPTION
- ENHANCEMENT: Move contained app response relay to a task and await both the request and response relay tasks
- FIX: Tell other channels to stop looping when 1 channel stops looping
- ENHANCEMENT: Propagate detailed errors and exit reasons all the way back to the router
- FIX/ENHANCEMENT: Remove hiding of errors (non-consumed results)
- ENHANCEMENT: Handle Channel 5xx, 4xx, and Other ExitReasons

Fixes #182 