### PR TITLE
Issue-188 - Use setup-rust

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 target/
+!target/*-unknown-linux-musl/release/extension
 **/bin/
 **/obj/
 out*/

--- a/.github/actions/setup-gcc-musl-cross/action.yml
+++ b/.github/actions/setup-gcc-musl-cross/action.yml
@@ -1,0 +1,39 @@
+name: 'setup-gcc-musl-cross'
+description: 'Installs and caches gcc musl cross-compiler'
+
+inputs:
+  arch:
+    description: 'Architecture of the target system (aarch, x86_64, etc.)'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Print values
+      shell: bash
+      run: |
+        echo "inputs.arch: ${{ inputs.arch }}"
+        echo "runner.os: ${{ runner.os }}"
+        echo "runner.arch: ${{ runner.arch }}"
+
+    - name: Restore gcc Cross Compiler from Cache
+      id: cache-gcc-musl-cross
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ inputs.arch }}-linux-musl-cross/
+        key: gcc-musl-cross-${{ inputs.arch }}-${{ runner.os }}-${{ runner.arch }}
+        lookup-only: ${{ inputs.lookup-only }}
+
+    - name: Install ARCH-unknown-linux-musl-gcc
+      if: steps.cache-gcc-musl-cross.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl -LO https://musl.cc/${{ inputs.arch }}-linux-musl-cross.tgz
+        tar -xzf ${{ inputs.arch }}-linux-musl-cross.tgz
+        rm ${{ inputs.arch }}-linux-musl-cross.tgz
+
+    - name: Add cross-compiler to the path
+      shell: bash
+      run: |
+        echo "$(pwd)/${{ inputs.arch }}-linux-musl-cross/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -248,18 +248,37 @@ jobs:
 
   build-extension-arm64:
     env:
+      ARCH: aarch64
       REGISTRY_IMAGE: public.ecr.aws/pwrdrvr/lambda-dispatch-extension${{ github.event_name == 'pull_request' && '-dev' || '' }}
     permissions:
       contents: read
       id-token: write
 
-    runs-on: [self-hosted, arm64]
+    runs-on: ubuntu-latest
+
+    # Using cross compiler now, can run on x64
+    # runs-on: [self-hosted, arm64]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install aarch64-unknown-linux-musl-gcc
+        run: |
+          curl -LO https://musl.cc/${{ env.ARCH }}-linux-musl-cross.tgz
+          tar -xzf ${{ env.ARCH }}-linux-musl-cross.tgz
+          echo "$(pwd)/${{ env.ARCH }}-linux-musl-cross/bin" >> $GITHUB_PATH
+          rm ${{ env.ARCH }}-linux-musl-cross.tgz
+
       - uses: moonrepo/setup-rust@v1
+        with:
+          targets: "${{ env.ARCH }}-unknown-linux-musl"
+
+      - name: Build extension
+        env:
+          CC: ${{ env.ARCH }}-linux-musl-gcc
+        run: |
+          cargo build --release --target ${{ env.ARCH }}-unknown-linux-musl
 
       - name: Docker meta
         id: meta
@@ -290,7 +309,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./DockerfileExtension
+          file: ./DockerfileExtensionCross
           build-args: BUILD_ARCH=linux-arm64
           platforms: linux/arm64
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=${{ github.event.pull_request.head.repo.fork == false }},name-canonical=true,push=${{ github.event.pull_request.head.repo.fork == false }}
@@ -326,7 +345,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install x86_64-linux-musl-gcc
+        run: |
+          curl -LO https://musl.cc/${{ env.ARCH }}-linux-musl-cross.tgz
+          tar -xzf ${{ env.ARCH }}-linux-musl-cross.tgz
+          echo "$(pwd)/${{ env.ARCH }}-linux-musl-cross/bin" >> $GITHUB_PATH
+          rm ${{ env.ARCH }}-linux-musl-cross.tgz
+
       - uses: moonrepo/setup-rust@v1
+        with:
+          targets: "${{ env.ARCH }}-unknown-linux-musl"
+
+      - name: Build extension
+        env:
+          CC: ${{ env.ARCH }}-linux-musl-gcc
+        run: |
+          cargo build --release --target ${{ env.ARCH }}-unknown-linux-musl
 
       - name: Docker meta
         id: meta
@@ -357,7 +391,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./DockerfileExtension
+          file: ./DockerfileExtensionCross
           build-args: |
             ARCH=x86_64
             TARGET_PLATFORM=linux/amd64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -273,6 +273,7 @@ jobs:
       - uses: moonrepo/setup-rust@v1
         with:
           targets: "${{ env.ARCH }}-unknown-linux-musl"
+          cache-target: release
 
       - name: Build extension
         env:
@@ -355,6 +356,7 @@ jobs:
       - uses: moonrepo/setup-rust@v1
         with:
           targets: "${{ env.ARCH }}-unknown-linux-musl"
+          cache-target: release
 
       - name: Build extension
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -263,12 +263,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install aarch64-unknown-linux-musl-gcc
-        run: |
-          curl -LO https://musl.cc/${{ env.ARCH }}-linux-musl-cross.tgz
-          tar -xzf ${{ env.ARCH }}-linux-musl-cross.tgz
-          echo "$(pwd)/${{ env.ARCH }}-linux-musl-cross/bin" >> $GITHUB_PATH
-          rm ${{ env.ARCH }}-linux-musl-cross.tgz
+      - name: Install gcc musl cross-compiler
+        uses: ./.github/actions/setup-gcc-musl-cross
+        with:
+          arch: ${{ env.ARCH }}
 
       - uses: moonrepo/setup-rust@v1
         with:
@@ -346,12 +344,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install x86_64-linux-musl-gcc
-        run: |
-          curl -LO https://musl.cc/${{ env.ARCH }}-linux-musl-cross.tgz
-          tar -xzf ${{ env.ARCH }}-linux-musl-cross.tgz
-          echo "$(pwd)/${{ env.ARCH }}-linux-musl-cross/bin" >> $GITHUB_PATH
-          rm ${{ env.ARCH }}-linux-musl-cross.tgz
+      - name: Install gcc musl cross-compiler
+        uses: ./.github/actions/setup-gcc-musl-cross
+        with:
+          arch: ${{ env.ARCH }}
 
       - uses: moonrepo/setup-rust@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,8 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        run: rustup update stable
+      - uses: moonrepo/setup-rust@v1
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -260,6 +259,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - uses: moonrepo/setup-rust@v1
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -324,6 +325,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - uses: moonrepo/setup-rust@v1
 
       - name: Docker meta
         id: meta

--- a/DockerfileExtensionCross
+++ b/DockerfileExtensionCross
@@ -1,0 +1,4 @@
+FROM scratch AS package-stage
+# ARG ARCH=x86_64
+ARG ARCH=aarch64
+COPY ./target/${ARCH}-unknown-linux-musl/release/extension /lambda-dispatch


### PR DESCRIPTION
- Build `aarch64` extension on x64 using cross-compiler
- Build outside of Docker as it's quite a bit faster
- Cache the cargo sources
- Cache the cross-compiler
- Upgrade the version of Rust
- Simplify the Dockerfile (just copies in the single built binary file)