### PR TITLE
Issue-199 - Use mock_router in app_request tests

### DIFF
--- a/extension/src/app_request.rs
+++ b/extension/src/app_request.rs
@@ -153,7 +153,7 @@ mod tests {
     // Start router server
     let mock_router_server = test_mock_router::setup_router(test_mock_router::RouterParams {
       request_method: test_mock_router::RequestMethod::Get,
-      channel_non_200_status_after_count: 1,
+      channel_non_200_status_after_count: -1,
       channel_non_200_status_code: StatusCode::CONFLICT,
       channel_panic_response_from_extension_on_count: -1,
       channel_panic_request_to_extension_before_start_on_count: -1,
@@ -161,6 +161,15 @@ mod tests {
       channel_panic_request_to_extension_before_close: false,
       ping_panic_after_count: -1,
       listener_type: test_mock_router::ListenerType::Http,
+    });
+
+    // Let the router return right away
+    tokio::spawn(async move {
+      mock_router_server
+        .release_request_tx
+        .send(())
+        .await
+        .unwrap();
     });
 
     let channel_url: Uri = format!(
@@ -230,6 +239,108 @@ mod tests {
     assert_eq!(goaway, false);
     assert_eq!(left_over_buf.is_empty(), false);
     assert_eq!(left_over_buf, b"HELLO WORLD");
+    assert_eq!(
+      mock_router_server
+        .request_count
+        .load(std::sync::atomic::Ordering::SeqCst),
+      1
+    );
+  }
+
+  #[tokio::test]
+  async fn test_read_until_req_headers_no_host_header() {
+    let lambda_id = "lambda_id".to_string();
+    let pool_id = "pool_id".to_string();
+    let channel_id = "channel_id".to_string();
+
+    // Start router server
+    let mock_router_server = test_mock_router::setup_router(test_mock_router::RouterParams {
+      request_method: test_mock_router::RequestMethod::GetNoHost,
+      channel_non_200_status_after_count: 1,
+      channel_non_200_status_code: StatusCode::CONFLICT,
+      channel_panic_response_from_extension_on_count: -1,
+      channel_panic_request_to_extension_before_start_on_count: -1,
+      channel_panic_request_to_extension_after_start: false,
+      channel_panic_request_to_extension_before_close: false,
+      ping_panic_after_count: -1,
+      listener_type: test_mock_router::ListenerType::Http,
+    });
+
+    // Let the router return right away
+    tokio::spawn(async move {
+      mock_router_server
+        .release_request_tx
+        .send(())
+        .await
+        .unwrap();
+    });
+
+    let channel_url: Uri = format!(
+      "http://localhost:{}/api/chunked/request/{}/{}",
+      mock_router_server.server.addr.port(),
+      lambda_id,
+      channel_id
+    )
+    .parse()
+    .unwrap();
+
+    // Setup our connection to the router
+    let router_client = create_router_client();
+
+    // Create the router request
+    let (_tx, recv) = mpsc::channel::<crate::prelude::Result<Frame<Bytes>>>(32 * 1024);
+    let boxed_body = BodyExt::boxed(StreamBody::new(recv));
+    let req = Request::builder()
+      .uri(&channel_url)
+      .method("POST")
+      .header(hyper::header::DATE, fmt_http_date(SystemTime::now()))
+      .header(hyper::header::HOST, channel_url.host().unwrap())
+      // The content-type that we're sending to the router is opaque
+      // as it contains another HTTP request/response, so may start as text
+      // with request/headers and then be binary after that - it should not be parsed
+      // by anything other than us
+      .header(hyper::header::CONTENT_TYPE, "application/octet-stream")
+      .header("X-Pool-Id", pool_id.to_string())
+      .header("X-Lambda-Id", &lambda_id)
+      .header("X-Channel-Id", &channel_id)
+      .body(boxed_body)
+      .unwrap();
+
+    let res = router_client.request(req).await.unwrap();
+    let (parts, mut res_stream) = res.into_parts();
+
+    let app_endpoint = "http://localhost:3000".parse::<Endpoint>().unwrap();
+
+    // Act
+    let result = read_until_req_headers(
+      app_endpoint,
+      &mut res_stream,
+      &pool_id,
+      &lambda_id,
+      &channel_id,
+    )
+    .await;
+
+    // Assert
+    assert_eq!(
+      parts.headers.get(HeaderName::from_static("content-type")),
+      Some(&hyper::http::HeaderValue::from_static(
+        "application/octet-stream"
+      ))
+    );
+    assert_ok!(&result);
+    let (app_req_builder, goaway, left_over_buf) = result.unwrap();
+    let host_header = app_req_builder.headers_ref().unwrap().get("host");
+    assert_eq!(host_header, None);
+    let test_header = app_req_builder.headers_ref().unwrap().get("test-header");
+    assert_eq!(test_header, Some(&HeaderValue::from_static("foo")));
+    let app_req_uri = app_req_builder.uri_ref().unwrap();
+    assert_eq!(
+      app_req_uri,
+      &Uri::from_static("http://localhost:3000/bananas/no_host_header")
+    );
+    assert_eq!(goaway, false);
+    assert_eq!(left_over_buf.is_empty(), true);
     assert_eq!(
       mock_router_server
         .request_count

--- a/extension/src/test_mock_router.rs
+++ b/extension/src/test_mock_router.rs
@@ -18,6 +18,7 @@ use tokio::{io::AsyncWriteExt, sync::mpsc::Sender};
 #[derive(Clone, Copy, PartialEq)]
 pub enum RequestMethod {
   Get,
+  GetNoHost,
   GetQuerySimple,
   GetQueryEncoded,
   GetQueryUnencodedBrackets,
@@ -233,6 +234,9 @@ pub fn setup_router(params: RouterParams) -> RouterResult {
                                 tx.write_all(data.as_bytes()).await.unwrap();
 
                                 let data = b"\r\n\r\n";
+                                tx.write_all(data).await.unwrap();
+                            } else if params.request_method == RequestMethod::GetNoHost {
+                                let data = b"GET /bananas/no_host_header HTTP/1.1\r\nTest-Header: foo\r\n\r\n";
                                 tx.write_all(data).await.unwrap();
                             } else {
                                 let data = b"GET /bananas HTTP/1.1\r\nHost: localhost\r\nTest-Header: foo\r\n";


### PR DESCRIPTION
- Fix error in mock router `Get` request type that did not wait to finish the headers